### PR TITLE
Full stack hardening: BATS suite, cuDNN rewrite, resume fixes, OpenClaw fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,4 +312,4 @@ The repository includes a comprehensive test suite in `test.sh` to validate the 
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
 
 ##
-2026/04/16
+Last updated: 2026-04-17 — Full stack validated: CUDA 13 + cuDNN 9.21.0 + llama.cpp + OpenWebUI + LibreChat + OpenClaw on Ubuntu 24.04 with NVIDIA RTXA5000-24Q passthrough.

--- a/tests/helpers.bats
+++ b/tests/helpers.bats
@@ -4,7 +4,6 @@
 #   format_component_status_label
 #   format_component_action_label
 #   record_component_outcome
-#   need_local_llm_work
 #   need_frontend_backend_target
 #   available_backend_count
 #   get_llama_{repo,cache,runtime_pid,runtime_log}_path
@@ -23,7 +22,6 @@ setup() {
     eval "$(extract_function format_component_status_label)"
     eval "$(extract_function format_component_action_label)"
     eval "$(extract_function record_component_outcome)"
-    eval "$(extract_function need_local_llm_work)"
     eval "$(extract_function need_frontend_backend_target)"
     eval "$(extract_function available_backend_count)"
     eval "$(extract_function get_llama_repo_path)"
@@ -145,37 +143,6 @@ setup() {
     record_component_outcome "Ollama" "install" "failed"
     record_component_outcome "llama.cpp" "repair" "failed"
     [ "${#FAILED_COMPONENTS[@]}" -eq 2 ]
-}
-
-# ─── need_local_llm_work ───────────────────────────────────────────────
-
-@test "need_llm_work: false when all component actions are skip" {
-    run need_local_llm_work
-    [ "$status" -eq 1 ]
-}
-
-@test "need_llm_work: true when LLAMA action is install" {
-    LLAMA_COMPONENT_ACTION="install"
-    run need_local_llm_work
-    [ "$status" -eq 0 ]
-}
-
-@test "need_llm_work: true when OLLAMA action is repair" {
-    OLLAMA_COMPONENT_ACTION="repair"
-    run need_local_llm_work
-    [ "$status" -eq 0 ]
-}
-
-@test "need_llm_work: true when OPENWEBUI action is install" {
-    OPENWEBUI_COMPONENT_ACTION="install"
-    run need_local_llm_work
-    [ "$status" -eq 0 ]
-}
-
-@test "need_llm_work: true when LIBRECHAT action is install" {
-    LIBRECHAT_COMPONENT_ACTION="install"
-    run need_local_llm_work
-    [ "$status" -eq 0 ]
 }
 
 # ─── need_frontend_backend_target ─────────────────────────────────────

--- a/tests/test-logic.bats
+++ b/tests/test-logic.bats
@@ -1,0 +1,552 @@
+#!/usr/bin/env bats
+#
+# test-logic.bats — regression suite for the pure-logic functions in
+# ubuntu-prep-setup.sh. Designed to guard a large refactoring pass
+# (dead-code removal + deduplication).
+#
+# Run:  cd /Users/christian/VSCode/ubuntu-prep && bats tests/test-logic.bats
+#
+# Install bats if missing:
+#   brew install bats-core        (macOS)
+#   npm  install -g bats          (cross-platform)
+#   sudo apt install bats         (Debian/Ubuntu)
+#
+# ─── Architecture note: testing nested functions ─────────────────────────
+#
+# The four dependency-resolution functions — apply_deps, validate_deps,
+# dep_label, dep_label_for — are *nested* functions defined inside main().
+# In bash, nested functions are only brought into scope when their enclosing
+# function runs. That means we cannot simply source the script and call them:
+# main() has to execute first, and main() is interactive and full of side
+# effects (sudo, apt, etc.) that we absolutely do not want in a unit test.
+#
+# Approach used here (matches the pre-existing tests in this directory):
+#   1. Locate each nested function body in the source with `sed` by matching
+#      its 4-space-indented `name() {` line and the matching closing `}`.
+#   2. `eval` the extracted text in the setup() function. This promotes the
+#      nested function to a top-level function in the test process.
+#   3. Similarly extract the `local -a DEP_MAP=(...)` literal, stripping the
+#      `local -a` prefix so the array survives past setup().
+#   4. Stub print_info / print_success / ensure_active_index so the dep
+#      logic can run without terminal output or ACTIVE_INDICES plumbing.
+#
+# Top-level functions (get_model_recommendations, llama_variant_to_model_backend)
+# are extracted with the simpler pattern: `sed -n '/^name() {/,/^}/p'`.
+#
+# Shared helpers live in tests/test_helper.bash.
+#
+
+load test_helper
+
+setup() {
+    SETUP_SCRIPT="${BATS_TEST_DIRNAME}/../ubuntu-prep-setup.sh"
+    [ -f "$SETUP_SCRIPT" ] || skip "ubuntu-prep-setup.sh not found at $SETUP_SCRIPT"
+
+    # Top-level functions — source directly.
+    eval "$(extract_function get_model_recommendations)"
+    eval "$(extract_function llama_variant_to_model_backend)"
+
+    # Nested functions + DEP_MAP (defined inside main()). See header comment.
+    load_dep_functions
+
+    # Initialise the selection arrays the same way main() does before any
+    # user interaction. Tests mutate these to exercise the logic.
+    reset_master_arrays
+}
+
+# ═════════════════════════════════════════════════════════════════════════
+# 1. get_model_recommendations — 7 VRAM tiers × 2 backends = 14 combos
+# ═════════════════════════════════════════════════════════════════════════
+#
+# Contract: given (backend, vram_gb), the function sets four globals —
+# REC_MODEL_CHAT, REC_MODEL_CODE, REC_MODEL_MOE, REC_MODEL_VISION — to
+# non-empty strings matching the case/esac in the source.
+
+# ─── All slots populated for every valid combo ───────────────────────────
+
+@test "get_model_recommendations: ollama/8  sets all four slots" {
+    get_model_recommendations "ollama" 8
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/16 sets all four slots" {
+    get_model_recommendations "ollama" 16
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/24 sets all four slots" {
+    get_model_recommendations "ollama" 24
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/32 sets all four slots" {
+    get_model_recommendations "ollama" 32
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/48 sets all four slots" {
+    get_model_recommendations "ollama" 48
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/72 sets all four slots" {
+    get_model_recommendations "ollama" 72
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: ollama/96 sets all four slots" {
+    get_model_recommendations "ollama" 96
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/8  sets all four slots" {
+    get_model_recommendations "llama" 8
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/16 sets all four slots" {
+    get_model_recommendations "llama" 16
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/24 sets all four slots" {
+    get_model_recommendations "llama" 24
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/32 sets all four slots" {
+    get_model_recommendations "llama" 32
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/48 sets all four slots" {
+    get_model_recommendations "llama" 48
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/72 sets all four slots" {
+    get_model_recommendations "llama" 72
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: llama/96 sets all four slots" {
+    get_model_recommendations "llama" 96
+    [ -n "$REC_MODEL_CHAT" ]
+    [ -n "$REC_MODEL_CODE" ]
+    [ -n "$REC_MODEL_MOE" ]
+    [ -n "$REC_MODEL_VISION" ]
+}
+
+# ─── Exact model-name assertions (ollama) ────────────────────────────────
+
+@test "get_model_recommendations: ollama/8  exact model names" {
+    get_model_recommendations "ollama" 8
+    [ "$REC_MODEL_CHAT"   = "gemma4:e4b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:7b" ]
+    [ "$REC_MODEL_MOE"    = "gemma4:e4b" ]
+    [ "$REC_MODEL_VISION" = "gemma4:e4b" ]
+}
+
+@test "get_model_recommendations: ollama/16 exact model names" {
+    get_model_recommendations "ollama" 16
+    [ "$REC_MODEL_CHAT"   = "qwen2.5:14b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:14b" ]
+    [ "$REC_MODEL_MOE"    = "gemma4:e4b" ]
+    [ "$REC_MODEL_VISION" = "minicpm-v" ]
+}
+
+@test "get_model_recommendations: ollama/24 exact model names" {
+    get_model_recommendations "ollama" 24
+    [ "$REC_MODEL_CHAT"   = "gemma4:26b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:32b" ]
+    [ "$REC_MODEL_MOE"    = "gemma4:26b" ]
+    [ "$REC_MODEL_VISION" = "llava:34b" ]
+}
+
+@test "get_model_recommendations: ollama/32 exact model names" {
+    get_model_recommendations "ollama" 32
+    [ "$REC_MODEL_CHAT"   = "qwen2.5:32b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:32b" ]
+    [ "$REC_MODEL_MOE"    = "mixtral:8x7b" ]
+    [ "$REC_MODEL_VISION" = "qwen2.5vl:32b" ]
+}
+
+@test "get_model_recommendations: ollama/48 exact model names" {
+    get_model_recommendations "ollama" 48
+    [ "$REC_MODEL_CHAT"   = "llama3.3:70b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:32b" ]
+    [ "$REC_MODEL_MOE"    = "mixtral:8x7b" ]
+    [ "$REC_MODEL_VISION" = "qwen2.5vl:32b" ]
+}
+
+@test "get_model_recommendations: ollama/72 exact model names" {
+    get_model_recommendations "ollama" 72
+    [ "$REC_MODEL_CHAT"   = "qwen2.5:72b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:32b" ]
+    [ "$REC_MODEL_MOE"    = "command-r-plus:104b" ]
+    [ "$REC_MODEL_VISION" = "qwen2.5vl:72b" ]
+}
+
+@test "get_model_recommendations: ollama/96 exact model names" {
+    get_model_recommendations "ollama" 96
+    [ "$REC_MODEL_CHAT"   = "qwen2.5:72b" ]
+    [ "$REC_MODEL_CODE"   = "qwen2.5-coder:32b" ]
+    [ "$REC_MODEL_MOE"    = "mixtral:8x22b" ]
+    [ "$REC_MODEL_VISION" = "qwen2.5vl:72b" ]
+}
+
+# ─── Exact model-name assertions (llama.cpp / HF repos) ──────────────────
+
+@test "get_model_recommendations: llama/8  exact repo paths" {
+    get_model_recommendations "llama" 8
+    [ "$REC_MODEL_CHAT"   = "unsloth/gemma-4-E4B-it-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-7B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "unsloth/gemma-4-E4B-it-GGUF" ]
+    [ "$REC_MODEL_VISION" = "unsloth/gemma-4-E4B-it-GGUF" ]
+}
+
+@test "get_model_recommendations: llama/16 exact repo paths" {
+    get_model_recommendations "llama" 16
+    [ "$REC_MODEL_CHAT"   = "bartowski/Qwen2.5-14B-Instruct-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "unsloth/gemma-4-E4B-it-GGUF" ]
+    [ "$REC_MODEL_VISION" = "cjpais/llava-v1.6-vicuna-13b-gguf" ]
+}
+
+@test "get_model_recommendations: llama/24 exact repo paths" {
+    get_model_recommendations "llama" 24
+    [ "$REC_MODEL_CHAT"   = "unsloth/gemma-4-26B-A4B-it-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "unsloth/gemma-4-26B-A4B-it-GGUF" ]
+    [ "$REC_MODEL_VISION" = "cjpais/llava-v1.6-34B-gguf" ]
+}
+
+@test "get_model_recommendations: llama/32 exact repo paths" {
+    get_model_recommendations "llama" 32
+    [ "$REC_MODEL_CHAT"   = "bartowski/Qwen2.5-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF" ]
+    [ "$REC_MODEL_VISION" = "unsloth/Qwen2.5-VL-32B-Instruct-GGUF" ]
+}
+
+@test "get_model_recommendations: llama/48 exact repo paths" {
+    get_model_recommendations "llama" 48
+    [ "$REC_MODEL_CHAT"   = "bartowski/Llama-3.3-70B-Instruct-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF" ]
+    [ "$REC_MODEL_VISION" = "unsloth/Qwen2.5-VL-32B-Instruct-GGUF" ]
+}
+
+@test "get_model_recommendations: llama/72 exact repo paths" {
+    get_model_recommendations "llama" 72
+    [ "$REC_MODEL_CHAT"   = "bartowski/Qwen2.5-72B-Instruct-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "bartowski/c4ai-command-r-plus-08-2024-GGUF" ]
+    [ "$REC_MODEL_VISION" = "unsloth/Qwen2.5-VL-72B-Instruct-GGUF" ]
+}
+
+@test "get_model_recommendations: llama/96 exact repo paths" {
+    get_model_recommendations "llama" 96
+    [ "$REC_MODEL_CHAT"   = "bartowski/Qwen2.5-72B-Instruct-GGUF" ]
+    [ "$REC_MODEL_CODE"   = "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF" ]
+    [ "$REC_MODEL_MOE"    = "MaziyarPanahi/Mixtral-8x22B-v0.1-GGUF" ]
+    [ "$REC_MODEL_VISION" = "unsloth/Qwen2.5-VL-72B-Instruct-GGUF" ]
+}
+
+# ─── Format sanity checks across all tiers ───────────────────────────────
+
+@test "get_model_recommendations: ollama tags never contain slashes" {
+    for vram in 8 16 24 32 48 72 96; do
+        get_model_recommendations "ollama" "$vram"
+        [[ "$REC_MODEL_CHAT"   != */* ]]
+        [[ "$REC_MODEL_CODE"   != */* ]]
+        [[ "$REC_MODEL_MOE"    != */* ]]
+        [[ "$REC_MODEL_VISION" != */* ]]
+    done
+}
+
+@test "get_model_recommendations: llama repos always use org/name format" {
+    for vram in 8 16 24 32 48 72 96; do
+        get_model_recommendations "llama" "$vram"
+        [[ "$REC_MODEL_CHAT"   == */* ]]
+        [[ "$REC_MODEL_CODE"   == */* ]]
+        [[ "$REC_MODEL_MOE"    == */* ]]
+        [[ "$REC_MODEL_VISION" == */* ]]
+    done
+}
+
+@test "get_model_recommendations: unknown VRAM tier leaves all slots empty" {
+    get_model_recommendations "ollama" 999
+    [ -z "$REC_MODEL_CHAT" ]
+    [ -z "$REC_MODEL_CODE" ]
+    [ -z "$REC_MODEL_MOE" ]
+    [ -z "$REC_MODEL_VISION" ]
+}
+
+@test "get_model_recommendations: unknown backend falls through to llama branch" {
+    # The if/else only special-cases "ollama"; everything else goes to the
+    # llama.cpp branch. Verify with a 24GB tier (arbitrary non-empty combo).
+    get_model_recommendations "bogus" 24
+    [ "$REC_MODEL_CHAT" = "unsloth/gemma-4-26B-A4B-it-GGUF" ]
+}
+
+# ═════════════════════════════════════════════════════════════════════════
+# 2. apply_deps / validate_deps — dependency cascade & auto-add logic
+# ═════════════════════════════════════════════════════════════════════════
+#
+# Index → menu item map (from MASTER_OPTIONS in main()):
+#   0  Update System          8  btop
+#   1  Oh My Zsh              9  nvtop
+#   2  Python                10  CUDA
+#   3  Docker                11  gcc
+#   4  NVM                   12  NVIDIA CTK
+#   5  Homebrew              13  cuDNN
+#   6  Gemini CLI            14  Local LLM
+#   7  NVIDIA Driver         15  OpenClaw
+#
+# DEP_MAP rules (req <- dep1 dep2 ...):
+#   4  <- 6, 15       NVM needed by Gemini, OpenClaw
+#   5  <- 15          Homebrew needed by OpenClaw
+#   3  <- 12          Docker needed by NVIDIA CTK
+#   7  <- 10, 12, 13  NVIDIA driver needed by CUDA, CTK, cuDNN
+#   10 <- 13          CUDA needed by cuDNN
+#   11 <- 10          gcc needed by CUDA
+
+# ─── Auto-add: CUDA pulls in NVIDIA driver + gcc ─────────────────────────
+
+@test "apply_deps: selecting CUDA(10) auto-adds NVIDIA driver(7) and gcc(11)" {
+    MASTER_SELECTIONS[10]=1
+    apply_deps 10
+    [ "${MASTER_SELECTIONS[7]}"  -eq 1 ]   # NVIDIA driver auto-selected
+    [ "${MASTER_SELECTIONS[11]}" -eq 1 ]   # gcc auto-selected
+}
+
+@test "validate_deps: CUDA(10) selected -> driver(7) and gcc(11) added" {
+    # validate_deps is the 'belt-and-suspenders' final pass — it should
+    # reach the same conclusion as apply_deps even when starting cold.
+    MASTER_SELECTIONS[10]=1
+    validate_deps || true   # nonzero return means "changes were made"
+    [ "${MASTER_SELECTIONS[7]}"  -eq 1 ]
+    [ "${MASTER_SELECTIONS[11]}" -eq 1 ]
+}
+
+# ─── Auto-add: OpenClaw pulls in NVM + Homebrew ──────────────────────────
+
+@test "apply_deps: selecting OpenClaw(15) auto-adds NVM(4) and Homebrew(5)" {
+    MASTER_SELECTIONS[15]=1
+    apply_deps 15
+    [ "${MASTER_SELECTIONS[4]}" -eq 1 ]    # NVM auto-selected
+    [ "${MASTER_SELECTIONS[5]}" -eq 1 ]    # Homebrew auto-selected
+}
+
+@test "validate_deps: OpenClaw(15) selected -> NVM(4) and Homebrew(5) added" {
+    MASTER_SELECTIONS[15]=1
+    validate_deps || true
+    [ "${MASTER_SELECTIONS[4]}" -eq 1 ]
+    [ "${MASTER_SELECTIONS[5]}" -eq 1 ]
+}
+
+# ─── Cascade-remove: deselecting NVIDIA driver clears dependents ─────────
+
+@test "apply_deps: deselecting NVIDIA driver(7) cascade-removes CUDA(10), CTK(12), cuDNN(13)" {
+    # Set up a state where everything GPU-related is selected, then drop
+    # the driver and expect all dependents to fall off.
+    MASTER_SELECTIONS[7]=1
+    MASTER_SELECTIONS[10]=1
+    MASTER_SELECTIONS[12]=1
+    MASTER_SELECTIONS[13]=1
+    MASTER_SELECTIONS[7]=0
+    apply_deps 7
+    [ "${MASTER_SELECTIONS[10]}" -eq 0 ]   # CUDA removed
+    [ "${MASTER_SELECTIONS[12]}" -eq 0 ]   # CTK removed
+    [ "${MASTER_SELECTIONS[13]}" -eq 0 ]   # cuDNN removed
+}
+
+# ─── validate_deps fixes a broken state ──────────────────────────────────
+
+@test "validate_deps: CUDA(10) selected without NVIDIA driver(7) -> driver auto-added" {
+    # Simulate a user (or goal-preset) leaving the state inconsistent:
+    # CUDA selected but its required driver not. validate_deps must fix it.
+    MASTER_SELECTIONS[10]=1
+    [ "${MASTER_SELECTIONS[7]}" -eq 0 ]    # precondition: driver NOT selected
+    validate_deps || true
+    [ "${MASTER_SELECTIONS[7]}" -eq 1 ]    # driver now selected
+}
+
+@test "validate_deps: fixes broken state AND adds gcc chain at the same time" {
+    # Combined scenario — CUDA selected, nothing else. validate_deps should
+    # pull in both driver(7) and gcc(11) in a single pass.
+    MASTER_SELECTIONS[10]=1
+    validate_deps || true
+    [ "${MASTER_SELECTIONS[7]}"  -eq 1 ]   # NVIDIA driver added
+    [ "${MASTER_SELECTIONS[11]}" -eq 1 ]   # gcc added
+    [ "${MASTER_SELECTIONS[10]}" -eq 1 ]   # CUDA stays selected
+}
+
+@test "validate_deps: returns nonzero (changed=1) when it had to fix something" {
+    # The function documents its contract via the return code:
+    #   0 = nothing to change, 1 = changes were made.
+    # Keep this behaviour pinned down for the refactor.
+    MASTER_SELECTIONS[10]=1
+    run validate_deps
+    [ "$status" -eq 1 ]
+}
+
+@test "validate_deps: returns zero when state is already consistent" {
+    MASTER_SELECTIONS[10]=1   # CUDA
+    MASTER_SELECTIONS[7]=1    # driver (dep already satisfied)
+    MASTER_SELECTIONS[11]=1   # gcc (dep already satisfied)
+    run validate_deps
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_deps: does not re-add a dep already marked installed" {
+    # If a dep is in MASTER_INSTALLED_STATE, it's already on the system —
+    # no need to reinstall it. validate_deps must respect that flag.
+    MASTER_SELECTIONS[10]=1          # CUDA selected
+    MASTER_INSTALLED_STATE[7]=1      # driver already on disk
+    validate_deps || true
+    [ "${MASTER_SELECTIONS[7]}" -eq 0 ]    # should NOT get re-selected
+    [ "${MASTER_SELECTIONS[11]}" -eq 1 ]   # gcc still gets added (not installed)
+}
+
+# ═════════════════════════════════════════════════════════════════════════
+# 3. dep_label / dep_label_for — case/esac label lookups
+# ═════════════════════════════════════════════════════════════════════════
+#
+# dep_label     covers the REQUIRED side of DEP_MAP (indices 3,4,5,7,10,11).
+# dep_label_for covers the DEPENDENT side (indices 6,10,12,13,15).
+# Both fall through to "item N" for unknown indices.
+
+# ─── dep_label: known indices ────────────────────────────────────────────
+
+@test "dep_label: 3 -> Docker" {
+    [ "$(dep_label 3)" = "Docker" ]
+}
+
+@test "dep_label: 4 -> NVM/Node.js" {
+    [ "$(dep_label 4)" = "NVM/Node.js" ]
+}
+
+@test "dep_label: 5 -> Homebrew" {
+    [ "$(dep_label 5)" = "Homebrew" ]
+}
+
+@test "dep_label: 7 -> NVIDIA GPU Driver" {
+    [ "$(dep_label 7)" = "NVIDIA GPU Driver" ]
+}
+
+@test "dep_label: 10 -> CUDA" {
+    [ "$(dep_label 10)" = "CUDA" ]
+}
+
+@test "dep_label: 11 -> gcc compiler" {
+    [ "$(dep_label 11)" = "gcc compiler" ]
+}
+
+@test "dep_label: unknown index falls through to 'item N'" {
+    [ "$(dep_label 99)" = "item 99" ]
+}
+
+@test "dep_label: index 0 (Update System) is not a dep — falls through" {
+    [ "$(dep_label 0)" = "item 0" ]
+}
+
+# ─── dep_label_for: known indices ────────────────────────────────────────
+
+@test "dep_label_for: 6 -> Gemini CLI" {
+    [ "$(dep_label_for 6)" = "Gemini CLI" ]
+}
+
+@test "dep_label_for: 10 -> CUDA Toolkit" {
+    [ "$(dep_label_for 10)" = "CUDA Toolkit" ]
+}
+
+@test "dep_label_for: 12 -> NVIDIA Container Toolkit" {
+    [ "$(dep_label_for 12)" = "NVIDIA Container Toolkit" ]
+}
+
+@test "dep_label_for: 13 -> cuDNN" {
+    [ "$(dep_label_for 13)" = "cuDNN" ]
+}
+
+@test "dep_label_for: 15 -> OpenClaw" {
+    [ "$(dep_label_for 15)" = "OpenClaw" ]
+}
+
+@test "dep_label_for: unknown index falls through to 'item N'" {
+    [ "$(dep_label_for 42)" = "item 42" ]
+}
+
+@test "dep_label_for: index 4 (NVM) is a required dep, not a dependent — falls through" {
+    # NVM is on the LEFT side of DEP_MAP, never the right. dep_label_for
+    # only knows the dependents, so 4 should hit the default branch.
+    [ "$(dep_label_for 4)" = "item 4" ]
+}
+
+# ═════════════════════════════════════════════════════════════════════════
+# 4. llama_variant_to_model_backend — always returns "llama"
+# ═════════════════════════════════════════════════════════════════════════
+#
+# Both case arms in the function body produce the same output, so this
+# function currently just maps any input to "llama". The test pins that
+# behaviour down — if it ever changes we want to know about it.
+
+@test "llama_variant_to_model_backend: llama_cpu  -> llama" {
+    [ "$(llama_variant_to_model_backend llama_cpu)" = "llama" ]
+}
+
+@test "llama_variant_to_model_backend: llama_cuda -> llama" {
+    [ "$(llama_variant_to_model_backend llama_cuda)" = "llama" ]
+}
+
+@test "llama_variant_to_model_backend: unknown variant -> llama (default arm)" {
+    [ "$(llama_variant_to_model_backend ollama)" = "llama" ]
+}
+
+@test "llama_variant_to_model_backend: empty input -> llama (default arm)" {
+    [ "$(llama_variant_to_model_backend "")" = "llama" ]
+}
+
+@test "llama_variant_to_model_backend: arbitrary string -> llama (default arm)" {
+    [ "$(llama_variant_to_model_backend foobar)" = "llama" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,64 @@
+# tests/test_helper.bash
+#
+# Shared helpers for the BATS test suite covering ubuntu-prep-setup.sh.
+#
+# The script defines both top-level functions (get_model_recommendations,
+# llama_variant_to_model_backend, ...) and nested functions inside main()
+# (apply_deps, validate_deps, dep_label, dep_label_for, ensure_active_index).
+#
+# Nested functions only come into existence when main() runs — but main()
+# is interactive and has side effects. To test them in isolation we extract
+# each function body with sed and eval it at the top level. This is the same
+# pattern used by the pre-existing tests in this directory.
+#
+# Usage: `load test_helper` from a .bats file after setting SETUP_SCRIPT.
+
+# Extract a top-level function (one whose definition starts in column 0).
+# Returns the text of the function so caller can `eval` it.
+extract_function() {
+    local fn_name="$1"
+    sed -n "/^${fn_name}() {/,/^}/p" "$SETUP_SCRIPT"
+}
+
+# Extract a nested function defined inside main(). These are indented by
+# exactly four spaces in the source file, and their closing `}` is also
+# at four-space indent.
+extract_nested_function() {
+    local fn_name="$1"
+    sed -n "/^    ${fn_name}() {/,/^    }$/p" "$SETUP_SCRIPT"
+}
+
+# Extract the DEP_MAP array definition from inside main() and strip the
+# `local -a` prefix. Without stripping, the array would be scoped to the
+# eval (which runs inside setup()) and disappear before the test body runs.
+extract_dep_map() {
+    sed -n '/^    local -a DEP_MAP=(/,/^    )$/p' "$SETUP_SCRIPT" \
+        | sed 's/local -a DEP_MAP=/DEP_MAP=/'
+}
+
+# Source the minimum scaffolding needed to exercise the nested dependency
+# functions. Call this from setup() after `SETUP_SCRIPT` has been set.
+#
+# Stubs print_info / print_success / ensure_active_index so the dep logic
+# can run silently without needing a terminal or populated ACTIVE_INDICES.
+load_dep_functions() {
+    print_info() { :; }
+    print_success() { :; }
+    # ensure_active_index is called by apply_deps/validate_deps. The real
+    # implementation mutates ACTIVE_INDICES; for selection-logic tests we
+    # don't care about that array, so stub it as a no-op.
+    ensure_active_index() { :; }
+
+    eval "$(extract_dep_map)"
+    eval "$(extract_nested_function dep_label)"
+    eval "$(extract_nested_function dep_label_for)"
+    eval "$(extract_nested_function apply_deps)"
+    eval "$(extract_nested_function validate_deps)"
+}
+
+# Reset MASTER_SELECTIONS and MASTER_INSTALLED_STATE to 16 zeros — the
+# same initial state main() sets up before the menu loop runs.
+reset_master_arrays() {
+    MASTER_SELECTIONS=(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+    MASTER_INSTALLED_STATE=(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+}

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -91,12 +91,9 @@ OPENCLAW_PORT="18789"
 LIBRECHAT_PORT="3080"
 OLLAMA_PULL_MODEL=""
 LLAMACPP_MODEL_REPO=""
-AUTO_UPDATE_OPENWEBUI="n"
 REPAIRED_COMPONENTS=()
 INSTALLED_COMPONENTS=()
 FAILED_COMPONENTS=()
-# shellcheck disable=SC2034 # Reserved for future use
-EXPOSE_LLAMA_SERVER="n"
 RUN_LLAMA_BENCH="n"
 LOAD_DEFAULT_MODEL="n"
 LLM_DEFAULT_MODEL_CHOICE=""
@@ -114,12 +111,10 @@ LLAMA_FIT="n"    # --fit on: auto-calculate ngl to fill VRAM
 LLAMA_FIT_CTX="" # --fit-ctx N: minimum ctx --fit will not shrink below
 
 # ─── Headless Mode ────────────────────────────────────────────────
-# Run non-interactively with sensible defaults. Every HEADLESS_* var
-# can be set as an environment variable before invocation.
+# Run non-interactively with sensible defaults.
 #
 # Usage:
 #   bash ubuntu-prep-setup.sh --headless
-#   HEADLESS_GOALS=llm HEADLESS_VRAM=24 bash ubuntu-prep-setup.sh --headless
 HEADLESS_MODE=false
 for arg in "$@"; do
     case "$arg" in
@@ -128,46 +123,10 @@ for arg in "$@"; do
     esac
 done
 
-HEADLESS_USER="${HEADLESS_USER:-}" # empty = current user
-HEADLESS_TIMEZONE="${HEADLESS_TIMEZONE:-America/Los_Angeles}"
-HEADLESS_GOALS="${HEADLESS_GOALS:-openclaw,llm}"           # subset of: openclaw,vgpu,llm
-HEADLESS_LLM_BACKEND="${HEADLESS_LLM_BACKEND:-ollama}"     # ollama | llama_cpu | llama_cuda
-HEADLESS_VRAM="${HEADLESS_VRAM:-16}"                       # 8|16|24|32|48|72|96
-HEADLESS_MODEL_CATEGORY="${HEADLESS_MODEL_CATEGORY:-chat}" # chat|code|moe|vision
-HEADLESS_INSTALL_OPENWEBUI="${HEADLESS_INSTALL_OPENWEBUI:-y}"
-HEADLESS_INSTALL_LIBRECHAT="${HEADLESS_INSTALL_LIBRECHAT:-n}"
-HEADLESS_EXPOSE_LLM="${HEADLESS_EXPOSE_LLM:-n}"
-HEADLESS_EXPOSE_OPENCLAW="${HEADLESS_EXPOSE_OPENCLAW:-n}"
-HEADLESS_LOAD_DEFAULT_MODEL="${HEADLESS_LOAD_DEFAULT_MODEL:-y}"
-HEADLESS_INSTALL_LLAMA_SERVICE="${HEADLESS_INSTALL_LLAMA_SERVICE:-n}"
-HEADLESS_ENABLE_UFW="${HEADLESS_ENABLE_UFW:-n}"
-HEADLESS_INSTALL_VGPU="${HEADLESS_INSTALL_VGPU:-n}"
-HEADLESS_REBOOT="${HEADLESS_REBOOT:-n}"
-HEADLESS_SECURITY_OPTS="${HEADLESS_SECURITY_OPTS:-c}" # "a"=all, "c"=confirm none, or "1,2,5"
 HEADLESS_CTX_SIZE="${HEADLESS_CTX_SIZE:-}"            # empty = auto from VRAM tier
 HEADLESS_CACHE_TYPE_K="${HEADLESS_CACHE_TYPE_K:-}"    # empty = auto; f16|q8_0|q4_0|bf16|turbo3|turbo4|...
 HEADLESS_CPU_MOE="${HEADLESS_CPU_MOE:-y}"             # y|n — offload MoE expert layers to CPU (default: on)
 HEADLESS_UBATCH="${HEADLESS_UBATCH:-}"                # empty = auto from VRAM tier; e.g. 1024
-
-# ask — drop-in replacement for `read -p`.
-# Interactive: reads from user; if input is empty, applies $default.
-# Headless:    echoes the default and assigns without prompting.
-# Usage: ask "Prompt text: " VARNAME "default"
-ask() {
-    local prompt="$1"
-    local var="$2"
-    local default="$3"
-
-    if [ "$HEADLESS_MODE" = true ]; then
-        echo -e "  \e[2m[headless] ${prompt}${default}\e[0m"
-        printf -v "$var" '%s' "$default"
-    else
-        read -rp "$prompt" "${var?}"
-        if [ -z "${!var}" ]; then
-            printf -v "$var" '%s' "$default"
-        fi
-    fi
-}
 
 reset_local_ai_component_state() {
     LLAMA_COMPONENT_ACTION="skip"
@@ -265,10 +224,6 @@ record_component_outcome() {
             FAILED_COMPONENTS+=("$component")
             ;;
     esac
-}
-
-need_local_llm_work() {
-    [[ "$LLAMA_COMPONENT_ACTION" != "skip" || "$OLLAMA_COMPONENT_ACTION" != "skip" || "$OPENWEBUI_COMPONENT_ACTION" != "skip" || "$LIBRECHAT_COMPONENT_ACTION" != "skip" ]]
 }
 
 need_frontend_backend_target() {
@@ -1106,13 +1061,6 @@ install_gemini_cli() {
 export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"
 [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\"
 exec gemini \"\$@\"
-NODE_BIN=\$(dirname \$(command -v node 2>/dev/null) 2>/dev/null)
-if [ -x \"\$NODE_BIN/gemini\" ]; then
-    exec \"\$NODE_BIN/gemini\" \"\$@\"
-else
-    # Fallback to npx to guarantee execution if path resolution fails
-    exec npx -y @google/gemini-cli \"\$@\"
-fi
 EOF"
     sudo chmod +x /usr/local/bin/gemini
 
@@ -3574,36 +3522,6 @@ SERVICEEOF
         "${docker_cmd[@]}"
         print_success "Open-WebUI installed and running on network host."
 
-        if [[ "$AUTO_UPDATE_OPENWEBUI" == "y" ]]; then
-            print_info "Configuring systemd to auto-update Open-WebUI on boot..."
-            sudo bash -c "cat <<EOF > /usr/local/bin/update-open-webui.sh
-#!/bin/bash
-sudo docker pull ghcr.io/open-webui/open-webui:main
-sudo docker stop open-webui 2>/dev/null || true
-sudo docker rm open-webui 2>/dev/null || true
-${docker_cmd[*]}
-EOF"
-            sudo chmod +x /usr/local/bin/update-open-webui.sh
-
-            sudo bash -c "cat <<EOF > /etc/systemd/system/open-webui-update.service
-[Unit]
-Description=Auto-update Open-WebUI Docker Container
-After=docker.service network-online.target
-Wants=network-online.target
-Requires=docker.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/update-open-webui.sh
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-EOF"
-            sudo systemctl daemon-reload
-            sudo systemctl enable open-webui-update.service
-            print_success "Open-WebUI auto-update service enabled."
-        fi
 
         print_info "NOTE: When you first open Open-WebUI, it will say 'Model not selected'."
         print_info "You must click the dropdown at the top of the screen to select your loaded model."

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -230,6 +230,26 @@ need_frontend_backend_target() {
     [[ "$OPENWEBUI_COMPONENT_ACTION" != "skip" || "$LIBRECHAT_COMPONENT_ACTION" != "skip" || "$OPENCLAW_COMPONENT_ACTION" != "skip" ]]
 }
 
+# Prompt for a yes/no answer, looping until y/Y/n/N or Enter is received.
+# Usage:  if ask_yn "Prompt [y/N]: " "n"; then ...
+# Arg 1: prompt string (including bracket hint)
+# Arg 2: default — "y" or "n" (default: "n")
+# Redirects (e.g. </dev/tty) are forwarded to the inner read.
+# Returns 0 for yes, 1 for no.
+ask_yn() {
+    local prompt="$1"
+    local default="${2:-n}"
+    local reply
+    while true; do
+        read -r -p "$prompt" reply
+        case "${reply:-$default}" in
+            y|Y) return 0 ;;
+            n|N) return 1 ;;
+            *)   echo "  Please enter y or n." ;;
+        esac
+    done
+}
+
 llama_variant_to_model_backend() {
     local variant="$1"
 
@@ -705,8 +725,7 @@ EOF
 
     # Interactive prompt for API keys
     print_info "API keys configuration file is ready at $TARGET_USER_HOME/.env.secrets"
-    read -p "Do you want to edit your API keys for '$TARGET_USER' now? [y/N]: " add_keys_now
-    if [[ "$add_keys_now" == "y" || "$add_keys_now" == "Y" ]]; then
+    if ask_yn "Do you want to edit your API keys for '$TARGET_USER' now? [y/N]: " "n"; then
         PS3="Please choose how to add your keys: "
         options=("Enter keys one-by-one" "Edit file manually with nano" "Skip")
         select opt in "${options[@]}"; do
@@ -1268,9 +1287,7 @@ NOUVEOF
         fi
 
         if [[ "$dl_failed" == true ]]; then
-            local retry_dl
-            read -p "Try another URL? [Y/n]: " retry_dl
-            if [[ "$retry_dl" == "n" || "$retry_dl" == "N" ]]; then
+            if ! ask_yn "Try another URL? [Y/n]: " "y"; then
                 echo "Skipping vGPU driver installation."
                 return 1
             fi
@@ -1379,9 +1396,7 @@ NOUVEOF
         fi
 
         if [[ "$tok_failed" == true ]] || [[ ! -f "$token_file_path" ]]; then
-            local retry_tok
-            read -p "Try another token URL? [Y/n]: " retry_tok
-            if [[ "$retry_tok" == "n" || "$retry_tok" == "N" ]]; then
+            if ! ask_yn "Try another token URL? [Y/n]: " "y"; then
                 print_info "Skipping vGPU token installation."
                 break
             fi
@@ -2970,36 +2985,31 @@ configure_local_llm_components() {
 
     if [[ "$effective_backend_target" == "llama" ]]; then
         echo ""
-        read -p "Allow external connections to Llama.CPP (add --host 0.0.0.0)? [y/N]: " expose_llm_choice
-        if [[ "$expose_llm_choice" == "y" || "$expose_llm_choice" == "Y" ]]; then
+        if ask_yn "Allow external connections to Llama.CPP (add --host 0.0.0.0)? [y/N]: " "n"; then
             EXPOSE_LLM_ENGINE="y"
         fi
     elif [[ "$effective_backend_target" == "ollama" ]]; then
         echo ""
-        read -p "Allow external connections to Ollama (bind 0.0.0.0:11434)? [y/N]: " expose_llm_choice
-        if [[ "$expose_llm_choice" == "y" || "$expose_llm_choice" == "Y" ]]; then
+        if ask_yn "Allow external connections to Ollama (bind 0.0.0.0:11434)? [y/N]: " "n"; then
             EXPOSE_LLM_ENGINE="y"
         fi
     fi
 
     if [[ "$LLAMA_COMPONENT_ACTION" != "skip" ]]; then
         echo ""
-        read -p "Install llama.cpp as a system service? [y/N]: " llama_service_choice
-        if [[ "$llama_service_choice" == "y" || "$llama_service_choice" == "Y" ]]; then
+        if ask_yn "Install llama.cpp as a system service? [y/N]: " "n"; then
             INSTALL_LLAMA_SERVICE="y"
         fi
 
         echo ""
-        read -p "Run llama.cpp benchmark after install? [y/N]: " llama_bench_choice
-        if [[ "$llama_bench_choice" == "y" || "$llama_bench_choice" == "Y" ]]; then
+        if ask_yn "Run llama.cpp benchmark after install? [y/N]: " "n"; then
             RUN_LLAMA_BENCH="y"
         fi
     fi
 
     if [[ "$LIBRECHAT_COMPONENT_ACTION" != "skip" ]]; then
         echo ""
-        read -p "Run LibreChat on port 8083 instead of 3080? [y/N]: " lc_port_choice
-        if [[ "$lc_port_choice" == "y" || "$lc_port_choice" == "Y" ]]; then
+        if ask_yn "Run LibreChat on port 8083 instead of 3080? [y/N]: " "n"; then
             LIBRECHAT_PORT="8083"
         fi
     fi
@@ -3018,8 +3028,7 @@ configure_local_llm_components() {
         configure_context_memory "${LLAMA_BUILD_VARIANT:-llama_cpu}"
     elif [[ "$LLAMA_COMPONENT_ACTION" != "skip" || "$OLLAMA_COMPONENT_ACTION" != "skip" ]]; then
         echo ""
-        read -p "Load a default model during this run? [y/N]: " load_model_choice
-        if [[ "$load_model_choice" == "y" || "$load_model_choice" == "Y" ]]; then
+        if ask_yn "Load a default model during this run? [y/N]: " "n"; then
             if [[ "$LLAMA_COMPONENT_ACTION" != "skip" ]]; then
                 configure_llm_model_prompt "${LLAMA_BUILD_VARIANT:-llama_cpu}"
                 configure_context_memory "${LLAMA_BUILD_VARIANT:-llama_cpu}"
@@ -3030,8 +3039,7 @@ configure_local_llm_components() {
     fi
 
     echo ""
-    read -p "Enable UFW automatically after this run if ports were opened? [y/N]: " ufw_choice
-    if [[ "$ufw_choice" == "y" || "$ufw_choice" == "Y" ]]; then
+    if ask_yn "Enable UFW automatically after this run if ports were opened? [y/N]: " "n"; then
         ENABLE_UFW_AUTOMATICALLY="y"
     fi
 
@@ -3046,8 +3054,7 @@ configure_openclaw_selection() {
 
     if [[ "$IS_DIFFERENT_USER" == false ]]; then
         echo -e "\n❌ [Blocked] OpenClaw cannot be installed for the current sudo user."
-        read -p "Do you want to create/select a dedicated standard user now? [y/N]: " fix_user
-        if [[ "$fix_user" == "y" || "$fix_user" == "Y" ]]; then
+        if ask_yn "Do you want to create/select a dedicated standard user now? [y/N]: " "n"; then
             echo ""
             determine_target_user
             detect_local_ai_components
@@ -4958,9 +4965,7 @@ main() {
     if [[ "$RESUME_MODE" == false && -f "$RESUME_STATE_FILE" ]]; then
         echo ""
         echo -e "\e[1;36m🔄 Detected a previous interrupted installation.\e[0m"
-        local _resume_choice
-        read -p "Resume where it left off? [Y/n]: " _resume_choice
-        if [[ "${_resume_choice:-Y}" == "Y" || "${_resume_choice:-Y}" == "y" ]]; then
+        if ask_yn "Resume where it left off? [Y/n]: " "y"; then
             RESUME_MODE=true
         else
             echo -e "Starting fresh — discarding previous state."
@@ -5430,8 +5435,7 @@ main() {
             echo -e "\n\e[1;31m⚠️  WARNING: Low Disk Space\e[0m"
             echo -e "You have selected options that require approximately \e[1;33m${required_gb}GB\e[0m of free space."
             echo -e "Your target partition ($TARGET_USER_HOME) only has \e[1;31m${free_space_gb}GB\e[0m available."
-            read -p "Do you want to proceed anyway? [y/N]: " proceed_space
-            if [[ "$proceed_space" != "y" && "$proceed_space" != "Y" ]]; then
+            if ! ask_yn "Do you want to proceed anyway? [y/N]: " "n"; then
                 echo -e "\n❌ Aborting installation to prevent disk exhaustion."
                 exit 1
             fi
@@ -5450,8 +5454,7 @@ main() {
                 echo -e "\n\e[1;31m⚠️  WARNING: Low System Memory\e[0m"
                 echo -e "You selected the Local LLM Stack, which generally requires at least \e[1;33m16GB\e[0m of RAM."
                 echo -e "Your system only has \e[1;31m${total_ram_gb}GB\e[0m of total memory."
-                read -p "Do you want to proceed anyway? Performance may be degraded. [y/N]: " proceed_ram
-                if [[ "$proceed_ram" != "y" && "$proceed_ram" != "Y" ]]; then
+                if ! ask_yn "Do you want to proceed anyway? Performance may be degraded. [y/N]: " "n"; then
                     echo -e "\n❌ Aborting installation to prevent system instability."
                     exit 1
                 fi
@@ -5510,9 +5513,7 @@ main() {
                         save_resume_state
                         echo -e "\e[1;36m  ✅ Progress saved. After reboot, just re-run this script — it will\e[0m"
                         echo -e "\e[1;36m     offer to continue automatically from where it left off.\e[0m"
-                        local _rbc
-                        read -p "Reboot now? [Y/n]: " _rbc
-                        if [[ "${_rbc:-Y}" == "Y" || "${_rbc:-Y}" == "y" ]]; then
+                        if ask_yn "Reboot now? [Y/n]: " "y"; then
                             print_info "Rebooting..."
                             sudo reboot
                             exit 0
@@ -5652,11 +5653,11 @@ main() {
             if [[ "$ENABLE_UFW_AUTOMATICALLY" == "y" ]]; then
                 print_info "Auto-enabling UFW firewall as selected in the configuration menu..."
                 enable_ufw="y"
-            else
-                read -p "Do you want to enable the UFW firewall now? (WARNING: Ensure SSH access is allowed if remote) [y/N]: " enable_ufw </dev/tty
+            elif ask_yn "Do you want to enable the UFW firewall now? (WARNING: Ensure SSH access is allowed if remote) [y/N]: " "n" </dev/tty; then
+                enable_ufw="y"
             fi
 
-            if [[ "$enable_ufw" == "y" || "$enable_ufw" == "Y" ]]; then
+            if [[ "$enable_ufw" == "y" ]]; then
                 sudo ufw default deny incoming &>/dev/null || true                                                    # ufw may not be installed
                 sudo ufw allow 22/tcp &>/dev/null || true                                                             # ufw may not be installed
                 if [[ "$INSTALL_LIBRECHAT" == "y" ]]; then sudo ufw allow $LIBRECHAT_PORT/tcp &>/dev/null || true; fi # ufw may not be installed
@@ -5710,8 +5711,7 @@ main() {
             done
             echo ""
         fi
-        read -p "Do you want to reboot now? [y/N]: " reboot_choice
-        if [[ "$reboot_choice" == "y" || "$reboot_choice" == "Y" ]]; then
+        if ask_yn "Do you want to reboot now? [y/N]: " "n"; then
             if [[ $_pending_after_reboot -eq 1 ]]; then
                 save_resume_state
                 echo -e "\e[1;32m✅ Progress saved. After reboot, re-run this script — it will offer to\e[0m"

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -563,8 +563,8 @@ determine_target_user() {
     echo -e "\n\e[1;36mSelect Target User for Installation:\e[0m"
     echo "This script runs system-wide installations (like Docker, Python, CUDA) using 'sudo'."
     echo "User-specific tools (like NVM, Oh My Zsh, OpenClaw) will be installed for the user you select below."
-    echo "  1. Current user ($USER)"
-    echo "  2. A different/new user (e.g., a dedicated 'openclaw' user)"
+    echo "  1. Sudo user ($USER)  — install everything for the user running this script"
+    echo "  2. A new or different standard user (e.g., a dedicated 'openclaw' user — recommended for OpenClaw)"
     local choice
     while true; do
         read -p "Your choice [1/2]: " choice

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -5984,44 +5984,12 @@ RESUME_OPENCLAW_RELEASE_CHANNEL="${OPENCLAW_RELEASE_CHANNEL:-latest}"
 RESUME_EXPOSE_OPENCLAW="${EXPOSE_OPENCLAW:-n}"
 RESUME_OPENCLAW_PORT="${OPENCLAW_PORT:-18789}"
 
-# Script path (so the service can re-run the right file)
-RESUME_SCRIPT_PATH="$(realpath "$0")"
 EOF
     sudo chmod 600 "$RESUME_STATE_FILE"
     print_info "Resume state saved to $RESUME_STATE_FILE"
 }
 
-# Install a oneshot systemd service that re-runs this script with --resume
-# once on the next boot, then disables itself.
-install_resume_service() {
-    local script_path
-    script_path=$(realpath "$0")
-    sudo tee /etc/systemd/system/ubuntu-prep-resume.service >/dev/null <<EOF
-[Unit]
-Description=Ubuntu Prep Setup — Resume after reboot
-After=network-online.target
-Wants=network-online.target
-# Run once then disable
-ConditionPathExists=${RESUME_STATE_FILE}
-
-[Service]
-Type=oneshot
-# Run as root so sudo commands inside the script work
-ExecStart=/bin/bash ${script_path} --resume
-ExecStartPost=/bin/systemctl disable ubuntu-prep-resume.service
-StandardOutput=journal+console
-StandardError=journal+console
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-EOF
-    sudo systemctl daemon-reload
-    sudo systemctl enable ubuntu-prep-resume.service
-    print_info "Resume service installed — script will continue automatically after reboot."
-}
-
-# Remove resume state file and service after a successful full run.
+# Remove resume state file and (if present from an older run) the legacy service.
 clear_resume_state() {
     if [[ -f "$RESUME_STATE_FILE" ]]; then
         sudo rm -f "$RESUME_STATE_FILE"

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -1550,11 +1550,11 @@ install_cudnn() {
     print_info "Installing cuDNN..."
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y zlib1g
 
+    # ── Detect CUDA major version ─────────────────────────────────────────────
     print_info "Auto-detecting CUDA major version..."
     local cuda_major="12" # Default fallback
-
     local detected_nvcc_path=""
-    detected_nvcc_path=$(get_cuda_nvcc_path || true) # may not exist yet
+    detected_nvcc_path=$(get_cuda_nvcc_path || true)
     if [[ -n "$detected_nvcc_path" ]]; then
         cuda_major=$("$detected_nvcc_path" --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p')
     elif dpkg -l | grep -q "cuda-toolkit-[0-9]"; then
@@ -1562,29 +1562,64 @@ install_cudnn() {
     elif command -v nvidia-smi &>/dev/null; then
         cuda_major=$(nvidia-smi | grep -i "CUDA Version" | sed -n 's/.*CUDA Version: \([0-9]\+\).*/\1/p')
     fi
-
     if [[ -z "$cuda_major" ]]; then cuda_major="12"; fi
-
     print_success "Auto-detected CUDA major version: $cuda_major"
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install "cudnn9-cuda-${cuda_major}"
 
-    print_info "Auto-detecting cuDNN library path..."
-    sudo ldconfig # Ensure cache is updated after installation
+    # ── Install cuDNN local repo .deb ─────────────────────────────────────────
+    # cuDNN requires its own separate local apt repository — it is NOT included
+    # in the standard CUDA toolkit repo. NVIDIA's official method:
+    #   1. Download the local repo .deb for the OS version
+    #   2. dpkg -i to register the repo
+    #   3. Copy the keyring
+    #   4. apt-get update + install the CUDA-versioned package
+    #
+    # Override CUDNN_LOCAL_DEB_URL in .env.secrets to pin a specific version.
+    local ubuntu_ver
+    ubuntu_ver=$(lsb_release -rs 2>/dev/null | tr -d '.')   # e.g. "2404"
+    local cudnn_ver="${CUDNN_VERSION:-9.21.0}"
+    local cudnn_deb_url="${CUDNN_LOCAL_DEB_URL:-https://developer.download.nvidia.com/compute/cudnn/${cudnn_ver}/local_installers/cudnn-local-repo-ubuntu${ubuntu_ver}-${cudnn_ver}_1.0-1_amd64.deb}"
+    local cudnn_deb_file="/tmp/cudnn-local-repo.deb"
+
+    print_info "Downloading cuDNN local repo installer (${cudnn_ver})..."
+    if ! curl_with_retry -fsSL -o "$cudnn_deb_file" "$cudnn_deb_url"; then
+        echo "❌ Failed to download cuDNN installer from: $cudnn_deb_url"
+        echo "   Set CUDNN_LOCAL_DEB_URL in ~/.env.secrets to override."
+        return 1
+    fi
+
+    print_info "Registering cuDNN local apt repository..."
+    sudo dpkg -i "$cudnn_deb_file"
+    # Copy the keyring installed by the .deb into the system keyring directory
+    sudo cp /var/cudnn-local-repo-ubuntu"${ubuntu_ver}"-"${cudnn_ver}"/cudnn-*-keyring.gpg \
+        /usr/share/keyrings/ 2>/dev/null || true
+    sudo apt-get update -qq
+    rm -f "$cudnn_deb_file"
+
+    # ── Install CUDA-versioned cuDNN package ──────────────────────────────────
+    # Try the detected CUDA version first; fall back to cuda-12 if unavailable.
+    local cudnn_pkg="cudnn9-cuda-${cuda_major}"
+    if ! apt-cache show "$cudnn_pkg" &>/dev/null; then
+        echo "⚠️  Package '$cudnn_pkg' not found — falling back to cudnn9-cuda-12"
+        cudnn_pkg="cudnn9-cuda-12"
+    fi
+    print_info "Installing ${cudnn_pkg}..."
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install "$cudnn_pkg"
+
+    # ── Export LD_LIBRARY_PATH system-wide ───────────────────────────────────
+    print_info "Detecting cuDNN library path..."
+    sudo ldconfig
     local cudnn_lib_path=""
-    cudnn_lib_path=$(get_cudnn_library_path || true) # may not be installed
+    cudnn_lib_path=$(get_cudnn_library_path || true)
 
     if [[ -n "$cudnn_lib_path" ]]; then
-        print_success "cuDNN library path found at: $cudnn_lib_path"
-
-        local cudnn_env_str="export LD_LIBRARY_PATH=\"$cudnn_lib_path:\$LD_LIBRARY_PATH\""
-        if sudo test -f "$TARGET_USER_HOME/.zshrc" && ! sudo grep -q "$cudnn_lib_path" "$TARGET_USER_HOME/.zshrc"; then
-            echo -e "\n# Add cuDNN to LD_LIBRARY_PATH\n${cudnn_env_str}" | sudo tee -a "$TARGET_USER_HOME/.zshrc" >/dev/null
-        fi
-        if sudo test -f "$TARGET_USER_HOME/.bashrc" && ! sudo grep -q "$cudnn_lib_path" "$TARGET_USER_HOME/.bashrc"; then
-            echo -e "\n# Add cuDNN to LD_LIBRARY_PATH\n${cudnn_env_str}" | sudo tee -a "$TARGET_USER_HOME/.bashrc" >/dev/null
-        fi
+        print_success "cuDNN library path: $cudnn_lib_path"
+        sudo tee /etc/profile.d/cudnn.sh >/dev/null <<CUDNNEOF
+# Added by ubuntu-prep-setup.sh — cuDNN system-wide LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="${cudnn_lib_path}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
+CUDNNEOF
+        sudo chmod 644 /etc/profile.d/cudnn.sh
     else
-        echo "⚠️ Could not auto-detect cuDNN library path for LD_LIBRARY_PATH export."
+        echo "⚠️ Could not detect cuDNN library path — LD_LIBRARY_PATH not updated."
     fi
 
     POST_INSTALL_ACTIONS+=("reboot")

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -123,10 +123,10 @@ for arg in "$@"; do
     esac
 done
 
-HEADLESS_CTX_SIZE="${HEADLESS_CTX_SIZE:-}"            # empty = auto from VRAM tier
-HEADLESS_CACHE_TYPE_K="${HEADLESS_CACHE_TYPE_K:-}"    # empty = auto; f16|q8_0|q4_0|bf16|turbo3|turbo4|...
-HEADLESS_CPU_MOE="${HEADLESS_CPU_MOE:-y}"             # y|n — offload MoE expert layers to CPU (default: on)
-HEADLESS_UBATCH="${HEADLESS_UBATCH:-}"                # empty = auto from VRAM tier; e.g. 1024
+HEADLESS_CTX_SIZE="${HEADLESS_CTX_SIZE:-}"         # empty = auto from VRAM tier
+HEADLESS_CACHE_TYPE_K="${HEADLESS_CACHE_TYPE_K:-}" # empty = auto; f16|q8_0|q4_0|bf16|turbo3|turbo4|...
+HEADLESS_CPU_MOE="${HEADLESS_CPU_MOE:-y}"          # y|n — offload MoE expert layers to CPU (default: on)
+HEADLESS_UBATCH="${HEADLESS_UBATCH:-}"             # empty = auto from VRAM tier; e.g. 1024
 
 reset_local_ai_component_state() {
     LLAMA_COMPONENT_ACTION="skip"
@@ -3526,7 +3526,6 @@ SERVICEEOF
         "${docker_cmd[@]}"
         print_success "Open-WebUI installed and running on network host."
 
-
         print_info "NOTE: When you first open Open-WebUI, it will say 'Model not selected'."
         print_info "You must click the dropdown at the top of the screen to select your loaded model."
         if [[ "$backend_target" == "llama" ]]; then
@@ -4283,9 +4282,9 @@ _render_summary() {
     [[ "$mode" == "file" ]] && is_file=1
 
     # ── Mode-aware output helpers ────────────────────────────────────
-    _banner()    { if [[ $is_file -eq 1 ]]; then echo "===== $1 ====="; else print_header "$1"; fi; }
-    _section()   { if [[ $is_file -eq 1 ]]; then echo "$1"; else echo -e "\e[1;36m$1\e[0m"; fi; }
-    _item()      { if [[ $is_file -eq 1 ]]; then echo "$1"; else print_info "$1"; fi; }
+    _banner() { if [[ $is_file -eq 1 ]]; then echo "===== $1 ====="; else print_header "$1"; fi; }
+    _section() { if [[ $is_file -eq 1 ]]; then echo "$1"; else echo -e "\e[1;36m$1\e[0m"; fi; }
+    _item() { if [[ $is_file -eq 1 ]]; then echo "$1"; else print_info "$1"; fi; }
     _subheader() { if [[ $is_file -eq 1 ]]; then echo "  -> $1"; else echo -e "  \e[1;36m-> $1\e[0m"; fi; }
 
     local nvm_cmd="export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\""
@@ -4372,15 +4371,15 @@ _render_summary() {
 
     if sudo test -s "$TARGET_USER_HOME/.nvm/nvm.sh"; then
         _item "Node.js & NPM (via NVM):"
-        sudo -u "$TARGET_USER" bash -c "$nvm_cmd; echo -n 'Node: '; node -v; echo -n 'NPM:  '; npm -v" 2>/dev/null \
-            || echo "  (run as $TARGET_USER with NVM loaded)"
+        sudo -u "$TARGET_USER" bash -c "$nvm_cmd; echo -n 'Node: '; node -v; echo -n 'NPM:  '; npm -v" 2>/dev/null ||
+            echo "  (run as $TARGET_USER with NVM loaded)"
         echo ""
     fi
 
     if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
         _item "Homebrew:"
-        sudo -u "$TARGET_USER" bash -c "$brew_cmd; brew --version | head -n 1" 2>/dev/null \
-            || echo "  Installed (source $TARGET_USER_HOME/.zshrc to activate)"
+        sudo -u "$TARGET_USER" bash -c "$brew_cmd; brew --version | head -n 1" 2>/dev/null ||
+            echo "  Installed (source $TARGET_USER_HOME/.zshrc to activate)"
         echo ""
     fi
 
@@ -4628,8 +4627,8 @@ CURLEOF
 
     local shell_changed=0 path_changed=0
     [[ "$unique_actions" == *"zsh"* ]] && shell_changed=1
-    if [[ "$unique_actions" == *"nvm"* || "$unique_actions" == *"brew"* \
-         || "$unique_actions" == *"cuda"* || "$unique_actions" == *"openclaw"* ]]; then
+    if [[ "$unique_actions" == *"nvm"* || "$unique_actions" == *"brew"* ||
+        "$unique_actions" == *"cuda"* || "$unique_actions" == *"openclaw"* ]]; then
         path_changed=1
     fi
 
@@ -4978,7 +4977,9 @@ main() {
         echo ""
         echo -e "\e[1;36m🔄 Resuming ubuntu-prep-setup.sh after reboot...\e[0m"
         # shellcheck source=/dev/null
-        source "$RESUME_STATE_FILE"
+        # The state file is root-owned (chmod 600), so we must read it via
+        # sudo and pipe into source through process substitution.
+        source <(sudo cat "$RESUME_STATE_FILE")
 
         # Restore global arrays from space-separated strings
         read -ra MASTER_SELECTIONS <<<"$RESUME_SELECTIONS"

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -1575,7 +1575,7 @@ install_cudnn() {
     #
     # Override CUDNN_LOCAL_DEB_URL in .env.secrets to pin a specific version.
     local ubuntu_ver
-    ubuntu_ver=$(lsb_release -rs 2>/dev/null | tr -d '.')   # e.g. "2404"
+    ubuntu_ver=$(lsb_release -rs 2>/dev/null | tr -d '.') # e.g. "2404"
     local cudnn_ver="${CUDNN_VERSION:-9.21.0}"
     local cudnn_deb_url="${CUDNN_LOCAL_DEB_URL:-https://developer.download.nvidia.com/compute/cudnn/${cudnn_ver}/local_installers/cudnn-local-repo-ubuntu${ubuntu_ver}-${cudnn_ver}_1.0-1_amd64.deb}"
     local cudnn_deb_file="/tmp/cudnn-local-repo.deb"
@@ -3905,6 +3905,56 @@ EOF
     local openclaw_config="$TARGET_USER_HOME/.openclaw/openclaw.json"
     if sudo test -f "$openclaw_config"; then
 
+        # ── Auto-configure provider if onboard didn't write one ───────────────
+        # 'openclaw onboard' run through 'su -c' loses TTY and silently skips
+        # the provider-selection wizard.  Detect this and write the config
+        # directly using the schema from a known-good onboard run.
+        if ! sudo jq -e '.models.providers | length > 0' "$openclaw_config" >/dev/null 2>&1; then
+            if [[ "$backend_target" == "llama" ]]; then
+                print_info "No provider in config — writing llama.cpp provider directly..."
+                local _prov_key="custom-127-0-0-1-8080"
+                local _prov_ctx="${LLAMA_CTX_SIZE:-65536}"
+                [[ "$_prov_ctx" -lt 16000 ]] && _prov_ctx=16000
+                local _prov_tmp
+                _prov_tmp=$(sudo mktemp)
+                sudo jq \
+                    --arg key "$_prov_key" \
+                    --argjson ctx "$_prov_ctx" \
+                    '. * {
+                        "models": {
+                            "mode": "merge",
+                            "providers": {
+                                ($key): {
+                                    "baseUrl": "http://127.0.0.1:8080/v1",
+                                    "api": "openai-completions",
+                                    "apiKey": "sk-llamacpp",
+                                    "models": [{
+                                        "id": "llama",
+                                        "name": "llama (Custom Provider)",
+                                        "contextWindow": $ctx,
+                                        "maxTokens": 4096,
+                                        "input": ["text"],
+                                        "cost": {"input":0,"output":0,"cacheRead":0,"cacheWrite":0},
+                                        "reasoning": false
+                                    }]
+                                }
+                            }
+                        },
+                        "agents": {
+                            "defaults": {
+                                "model": {"primary": ($key + "/llama")},
+                                "models": {($key + "/llama"): {"alias": "llama"}}
+                            }
+                        }
+                    }' "$openclaw_config" | sudo tee "$_prov_tmp" >/dev/null &&
+                    sudo mv "$_prov_tmp" "$openclaw_config" &&
+                    sudo chown "$TARGET_USER":"$TARGET_USER" "$openclaw_config"
+                print_success "llama.cpp provider written (${_prov_key}/llama, ctx: ${_prov_ctx})."
+            else
+                echo "⚠️  No provider configured and backend is not llama — run 'openclaw configure --section model' manually as $TARGET_USER."
+            fi
+        fi
+
         # ── Combined: Configure & Secure OpenClaw ────────────────────────────
         # Items 1-5 : security hardening
         # Items 6-9 : gateway/network settings
@@ -4020,7 +4070,7 @@ EOF
             oc_jq_filter="$oc_jq_filter | .gateway.auth.rateLimit = {\"maxAttempts\": 10, \"windowMs\": 60000, \"lockoutMs\": 300000}"
         fi
         oc_jq_filter="$oc_jq_filter | .agents.defaults.compaction.reserveTokensFloor = 20000"
-        oc_jq_filter="$oc_jq_filter | (.providers // {}) as \$p | if (\$p | keys | map(select(startswith(\"custom-127\"))) | length) > 0 then (.providers[(.providers | keys | map(select(startswith(\"custom-127\"))))[0]].models[0].contextWindow = $oc_ctx) else . end"
+        oc_jq_filter="$oc_jq_filter | (.models.providers // {}) as \$p | if (\$p | keys | map(select(startswith(\"custom-127\"))) | length) > 0 then (.models.providers[(.models.providers | keys | map(select(startswith(\"custom-127\"))))[0]].models[0].contextWindow = $oc_ctx) else . end"
 
         local _jq_out
         _jq_out=$(sudo jq "$oc_jq_filter" "$openclaw_config") || { echo "⚠️  jq filter failed — config not updated." >&2; }
@@ -4035,6 +4085,22 @@ EOF
                 systemctl --user restart openclaw.service 2>/dev/null || true"
         fi
         print_success "OpenClaw gateway configured (bind: $bind_mode, port: $OPENCLAW_PORT, context: $oc_ctx)."
+
+        # Patch the systemd service ExecStart port — 'openclaw daemon install'
+        # hardcodes --port 18789 regardless of gateway.port in the JSON config.
+        for _oc_svc_name in "openclaw-gateway.service" "openclaw.service"; do
+            local _oc_svc_path="$TARGET_USER_HOME/.config/systemd/user/$_oc_svc_name"
+            if sudo test -f "$_oc_svc_path"; then
+                sudo sed -i "s/gateway --port [0-9]*/gateway --port $OPENCLAW_PORT/g" "$_oc_svc_path"
+                sudo -u "$TARGET_USER" bash -c "
+                    export XDG_RUNTIME_DIR=\"/run/user/\$(id -u)\"
+                    export DBUS_SESSION_BUS_ADDRESS=\"unix:path=\${XDG_RUNTIME_DIR}/bus\"
+                    systemctl --user daemon-reload
+                    systemctl --user restart $_oc_svc_name 2>/dev/null || true"
+                print_success "OpenClaw service port patched to $OPENCLAW_PORT in $_oc_svc_name."
+                break
+            fi
+        done
 
         # UFW for LAN exposure (item 6)
         if [[ "$EXPOSE_OPENCLAW" == "y" ]]; then

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -4262,442 +4262,221 @@ verify_installations() {
 
 # --- Final Summary ---
 
-print_final_summary() {
-    # Ensure newly installed binaries are in the script's PATH for verification
-    [ -d "/usr/local/cuda/bin" ] && export PATH="/usr/local/cuda/bin:$PATH"
+# _render_summary <mode>
+#   mode="terminal" - writes colored ANSI summary to stdout (used by print_final_summary)
+#   mode="file"     - writes plain text to stdout; caller redirects to file
+#
+# Shared body used by both print_final_summary (interactive end-of-install banner)
+# and save_ai_settings_file (~/AI-settings.txt dump, also triggered by 's' goal-menu key).
+#
+# File-mode adds: metadata header, Hardware section, llama-server runtime introspection,
+# OpenClaw token URL, ufw rules in Next Steps, target-user footer.
+# Terminal-mode uses colored helpers (print_info / print_header) and the more concise
+# section layout the user sees during install.
+_render_summary() {
+    local mode="${1:-terminal}"
+    local is_file=0
+    [[ "$mode" == "file" ]] && is_file=1
 
-    # Make array unique by converting to a string, sorting, and converting back
-    local unique_actions
-    unique_actions=$(echo "${POST_INSTALL_ACTIONS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    # ── Mode-aware output helpers ────────────────────────────────────
+    _banner()    { if [[ $is_file -eq 1 ]]; then echo "===== $1 ====="; else print_header "$1"; fi; }
+    _section()   { if [[ $is_file -eq 1 ]]; then echo "$1"; else echo -e "\e[1;36m$1\e[0m"; fi; }
+    _item()      { if [[ $is_file -eq 1 ]]; then echo "$1"; else print_info "$1"; fi; }
+    _subheader() { if [[ $is_file -eq 1 ]]; then echo "  -> $1"; else echo -e "  \e[1;36m-> $1\e[0m"; fi; }
 
-    print_header "Installed Components & Verification"
+    local nvm_cmd="export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\""
+    local brew_cmd="[ -f /home/linuxbrew/.linuxbrew/bin/brew ] && eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
+    local lan_ip
+    lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
 
-    echo -e "\e[1;36mInstalled Options:\e[0m"
+    local unique_actions=""
+    if [[ ${#POST_INSTALL_ACTIONS[@]} -gt 0 ]]; then
+        unique_actions=$(printf '%s\n' "${POST_INSTALL_ACTIONS[@]}" | sort -u | tr '\n' ' ')
+    fi
+
+    _banner "Installed Components & Verification"
+
+    # File-only: metadata header
+    if [[ $is_file -eq 1 ]]; then
+        echo "Generated: $(date)"
+        echo "Host:      $(hostname)  (${lan_ip:-<ip>})"
+        echo ""
+    fi
+
+    # ── Installed Options ────────────────────────────────────────────
+    _section "Installed Options:"
+    local found_opt=0
     for i in "${!MASTER_OPTIONS[@]}"; do
-        if [[ ${MASTER_INSTALLED_STATE[$i]} -eq 1 || ${MASTER_SELECTIONS[$i]} -eq 1 ]]; then
+        if [[ ${MASTER_INSTALLED_STATE[$i]:-0} -eq 1 || ${MASTER_SELECTIONS[$i]:-0} -eq 1 ]]; then
             echo "  - ${MASTER_OPTIONS[$i]}"
+            found_opt=1
         fi
     done
+    [[ $is_file -eq 1 && $found_opt -eq 0 ]] && echo "  (none recorded)"
     echo ""
 
+    # ── Components lists ─────────────────────────────────────────────
     if [[ ${#INSTALLED_COMPONENTS[@]} -gt 0 ]]; then
-        echo -e "\e[1;36mNewly Installed Components:\e[0m"
+        _section "Newly Installed Components:"
         printf '  - %s\n' "${INSTALLED_COMPONENTS[@]}"
         echo ""
     fi
 
     if [[ ${#REPAIRED_COMPONENTS[@]} -gt 0 ]]; then
-        echo -e "\e[1;36mRepaired Components:\e[0m"
+        _section "Repaired Components:"
         printf '  - %s\n' "${REPAIRED_COMPONENTS[@]}"
         echo ""
     fi
 
     if [[ ${#FAILED_COMPONENTS[@]} -gt 0 ]]; then
-        echo -e "\e[1;31mComponents That Failed Verification:\e[0m"
+        if [[ $is_file -eq 1 ]]; then
+            echo "Failed Components:"
+        else
+            echo -e "\e[1;31mComponents That Failed Verification:\e[0m"
+        fi
         printf '  - %s\n' "${FAILED_COMPONENTS[@]}"
         echo ""
     fi
 
-    # User environment helpers
-    local nvm_cmd="export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\""
-    local brew_cmd="[ -f /home/linuxbrew/.linuxbrew/bin/brew ] && eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
-
-    if sudo test -d "$TARGET_USER_HOME/.oh-my-zsh"; then
-        print_info "Zsh / Oh My Zsh:"
-        zsh --version || echo "Installed"
-        echo ""
-    fi
-
-    if command -v python3 &>/dev/null; then
-        print_info "Python:"
-        python3 --version
-        echo ""
-    fi
-
-    if command -v docker &>/dev/null; then
-        print_info "Docker:"
-        docker --version
-        echo ""
-    fi
-
-    if sudo test -s "$TARGET_USER_HOME/.nvm/nvm.sh"; then
-        print_info "Node.js & NPM (via NVM):"
-        sudo -u "$TARGET_USER" bash -c "$nvm_cmd; echo -n 'Node: '; node -v; echo -n 'NPM: '; npm -v"
-        echo ""
-    fi
-
-    if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
-        print_info "Homebrew:"
-        sudo -u "$TARGET_USER" bash -c "$brew_cmd; brew --version | head -n 1"
-        echo ""
-    fi
-
-    if command -v gemini &>/dev/null; then
-        print_info "Google Gemini CLI:"
-        echo "Installed at $(command -v gemini)"
-        echo ""
-    fi
-
-    if command -v nvidia-smi &>/dev/null; then
-        print_info "NVIDIA GPU Driver:"
-        nvidia-smi --query-gpu=driver_version,name --format=csv,noheader || nvidia-smi
-        nvidia-smi -q | grep -i "license" || true # display-only: may not match
-        echo ""
-    fi
-
-    if command -v btop &>/dev/null; then
-        print_info "btop (System Monitor):"
-        btop --version | head -n 1
-        echo ""
-    fi
-
-    if command -v nvtop &>/dev/null; then
-        print_info "nvtop (GPU Monitor):"
-        nvtop --version
-        echo ""
-    fi
-
-    if command -v gcc &>/dev/null; then
-        print_info "gcc Compiler:"
-        gcc --version | head -n 1
-        echo ""
-    fi
-
-    if command -v nvcc &>/dev/null; then
-        print_info "CUDA:"
-        nvcc --version
-        echo ""
-    fi
-
-    if ensure_nvidia_ctk_for_current_shell >/dev/null 2>&1; then
-        print_info "NVIDIA Container Toolkit:"
-        nvidia-ctk --version
-        echo ""
-    fi
-
-    if has_cudnn_available; then
-        print_info "cuDNN Library:"
-        dpkg -l | grep -E 'cudnn|libcudnn'
-        echo ""
-    fi
-
-    if command -v ollama &>/dev/null; then
-        print_info "Ollama:"
-        ollama --version
-        echo ""
-    fi
-
-    if command -v llama-server &>/dev/null; then
-        print_info "llama.cpp:"
-        echo "llama-server installed at $(command -v llama-server)"
-        echo ""
-        echo -e "  \e[1;36m-> Service commands:\e[0m"
-        echo "     sudo systemctl start   llama-server"
-        echo "     sudo systemctl stop    llama-server"
-        echo "     sudo systemctl restart llama-server"
-        echo "     sudo systemctl status  llama-server"
-        echo "     sudo journalctl -u llama-server -f   # follow live logs"
-        if systemctl is-active --quiet llama-server 2>/dev/null; then
-            echo ""
-            echo -e "  \e[1;36m-> To test your live API server from the terminal, run:\e[0m"
-            cat <<'EOF'
-     curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
-       -H "Content-Type: application/json" \
-       -H "Authorization: Bearer sk-llamacpp" \
-       -d '{
-         "messages": [
-           {"role": "system", "content": "You are a helpful coding assistant."},
-           {"role": "user", "content": "Write a quick haiku about the Linux command line."}
-         ],
-         "temperature": 0.7,
-         "max_tokens": 150
-       }' | jq -r '.choices[0].message.content'
-EOF
-        fi
-        echo ""
-    fi
-
-    if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^open-webui$'; then
-        print_info "Open-WebUI (Docker):"
-        local webui_status
-        webui_status=$(sudo docker inspect -f '{{.State.Status}}' open-webui)
-        echo "Status: $webui_status"
-        if command -v llama-server &>/dev/null; then
-            echo -e "  \e[1;36m-> How to connect Open-WebUI to llama.cpp:\e[0m"
-            echo "     1. Open WebUI in your browser (e.g., http://localhost:8081)"
-            echo "     2. Go to Profile (bottom left) -> Settings -> Connections"
-            echo "     3. Under 'OpenAI API', verify the URL is 'http://127.0.0.1:8080/v1' and Key is 'sk-llamacpp'"
-            echo "     4. Click the 'Verify Connection' icon. Your model should automatically load!"
-        fi
-        echo ""
-    fi
-
-    if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qi 'librechat'; then
-        print_info "LibreChat (Docker):"
-        local lc_status
-        lc_status=$(sudo docker inspect -f '{{.State.Status}}' LibreChat-api 2>/dev/null || echo "Running")
-        echo "Status: $lc_status"
-
-        local display_port="$LIBRECHAT_PORT"
-        if sudo test -f "$TARGET_USER_HOME/LibreChat/.env"; then
-            local real_port
-            real_port=$(sudo grep "^PORT=" "$TARGET_USER_HOME/LibreChat/.env" | cut -d'=' -f2 | tr -d '\r')
-            if [[ -n "$real_port" ]]; then display_port="$real_port"; fi
-        fi
-
-        echo -e "  \e[1;36m-> How to access LibreChat:\e[0m"
-        echo "     1. Open LibreChat in your browser (e.g., http://localhost:$display_port)"
-        echo "     2. Click 'Register' to create your admin account."
-        echo ""
-    fi
-
-    local oc_status_bin
-    oc_status_bin=$(sudo -u "$TARGET_USER" bash -c \
-        "export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\"; command -v openclaw 2>/dev/null || true" 2>/dev/null || true)
-    if [[ -n "$oc_status_bin" ]] || sudo test -f "$TARGET_USER_HOME/.local/bin/openclaw"; then
-        print_info "OpenClaw:"
-        sudo -u "$TARGET_USER" bash -c \
-            "export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\"; openclaw --version 2>/dev/null || echo 'Installed'"
-        echo ""
-    fi
-
-    print_info "System Hostname Resolution:"
-    local current_hostname
-    current_hostname=$(hostname)
-    if hostname -i &>/dev/null; then
-        print_success "Hostname '$current_hostname' resolves correctly ($(hostname -i | awk '{print $1}' | head -n 1))."
-    else
-        echo -e "\e[1;31m⚠️  WARNING: Hostname '$current_hostname' does not resolve.\e[0m"
-        echo "   Please add '127.0.1.1 $current_hostname' to your /etc/hosts file to prevent network and sudo delays."
-    fi
-    echo ""
-
-    if [[ -z "$unique_actions" ]]; then
-        return
-    fi
-
-    print_header "Next Steps & Important Information"
-
-    local shell_changed=0
-    if [[ "$unique_actions" == *"zsh"* ]]; then shell_changed=1; fi
-
-    local path_changed=0
-    if [[ "$unique_actions" == *"nvm"* || "$unique_actions" == *"brew"* || "$unique_actions" == *"cuda"* || "$unique_actions" == *"openclaw"* ]]; then path_changed=1; fi
-
-    if [[ "$unique_actions" == *"docker"* ]]; then
-        print_info "To use Docker without 'sudo' IMMEDIATELY in this terminal, run: newgrp docker"
-        print_info "Otherwise, you must LOG OUT and LOG BACK IN to apply the group change globally."
-        print_info "Then, test your installation with: docker run hello-world"
-        echo "" # Newline for spacing
-    fi
-
-    if [[ $shell_changed -eq 1 ]]; then
-        echo -e "\e[1;33mYour default shell has been changed to Zsh.\e[0m"
-        echo -e "To start using Zsh and activate all newly installed commands (like nvm, node, gemini), you must either:"
-        echo -e "  1. \e[1;32mOpen a NEW terminal window.\e[0m (Recommended)"
-        echo -e "  2. OR, if you are logged in as '$TARGET_USER', paste the following command into your current terminal:"
-        echo "source $TARGET_USER_HOME/.zshrc"
-        echo "" # Newline for spacing
-    elif [[ $path_changed -eq 1 ]]; then
-        # Determine the correct rc file based on the user's default shell
-        local rc_file=""
-        if sudo test -f "$TARGET_USER_HOME/.zshrc"; then
-            rc_file="$TARGET_USER_HOME/.zshrc"
-        elif sudo test -f "$TARGET_USER_HOME/.bashrc"; then
-            rc_file="$TARGET_USER_HOME/.bashrc"
-        fi
-        echo -e "\e[1;33mTo activate newly installed commands for '$TARGET_USER' (like nvm, node, gemini), they must either:\e[0m"
-        echo -e "  1. \e[1;32mOpen a NEW terminal window.\e[0m"
-        if [[ -n "$rc_file" ]]; then
-            echo -e "  2. OR, run the following command in your CURRENT terminal:"
-            echo "source ${rc_file}"
-        fi
-        echo "" # Newline for spacing
-    fi
-
-    if [[ "$unique_actions" == *"reboot"* ]]; then
-        print_info "A system reboot is highly recommended to ensure all NVIDIA drivers are loaded correctly."
-    fi
-
-    # Save clean summary to file at the end of every install run
-    save_ai_settings_file
-}
-
-# Write a clean, plain-text AI-settings summary to ~/AI-settings.txt
-# Called from print_final_summary (after install) and the 's' goal-menu key.
-save_ai_settings_file() {
-    local out_file="$HOME/AI-settings.txt"
-    local _lan_ip
-    _lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
-    local _nvm_cmd="export NVM_DIR=\"$TARGET_USER_HOME/.nvm\"; [ -s \"\$NVM_DIR/nvm.sh\" ] && source \"\$NVM_DIR/nvm.sh\""
-    local _brew_cmd="[ -f /home/linuxbrew/.linuxbrew/bin/brew ] && eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
-    {
-        echo "===== Installed Components & Verification ====="
-        echo "Generated: $(date)"
-        echo "Host:      $(hostname)  (${_lan_ip:-<ip>})"
-        echo ""
-
-        # --- Installed options ---
-        if [[ ${#MASTER_OPTIONS[@]} -gt 0 ]]; then
-            echo "Installed Options:"
-            local _found_opt=0
-            for _i in "${!MASTER_OPTIONS[@]}"; do
-                if [[ ${MASTER_INSTALLED_STATE[$_i]:-0} -eq 1 || ${MASTER_SELECTIONS[$_i]:-0} -eq 1 ]]; then
-                    echo "  - ${MASTER_OPTIONS[$_i]}"
-                    _found_opt=1
-                fi
-            done
-            [[ $_found_opt -eq 0 ]] && echo "  (none recorded)"
-            echo ""
-        fi
-
-        if [[ ${#INSTALLED_COMPONENTS[@]} -gt 0 ]]; then
-            echo "Newly Installed Components:"
-            printf '  - %s\n' "${INSTALLED_COMPONENTS[@]}"
-            echo ""
-        fi
-
-        if [[ ${#REPAIRED_COMPONENTS[@]} -gt 0 ]]; then
-            echo "Repaired Components:"
-            printf '  - %s\n' "${REPAIRED_COMPONENTS[@]}"
-            echo ""
-        fi
-
-        if [[ ${#FAILED_COMPONENTS[@]} -gt 0 ]]; then
-            echo "Failed Components:"
-            printf '  - %s\n' "${FAILED_COMPONENTS[@]}"
-            echo ""
-        fi
-
-        # --- Hardware ---
+    # File-only: Hardware section
+    if [[ $is_file -eq 1 ]]; then
         echo "Hardware:"
         echo "  RAM:  ${SYSTEM_RAM_GB:-?} GB"
         echo "  VRAM: ${GPU_VRAM_GB:-?} GB"
         echo "  GPU:  ${GPU_STATUS:-unknown}"
         echo ""
+    fi
 
-        # --- Per-component software sections (mirrors print_final_summary) ---
-        if sudo test -d "$TARGET_USER_HOME/.oh-my-zsh" && command -v zsh &>/dev/null; then
-            echo "Zsh / Oh My Zsh:"
-            zsh --version 2>/dev/null || echo "Installed"
-            echo ""
-        fi
+    # ── Per-component software sections ──────────────────────────────
+    if sudo test -d "$TARGET_USER_HOME/.oh-my-zsh" && command -v zsh &>/dev/null; then
+        _item "Zsh / Oh My Zsh:"
+        zsh --version 2>/dev/null || echo "Installed"
+        echo ""
+    fi
 
-        if command -v python3 &>/dev/null; then
-            echo "Python:"
-            python3 --version
-            echo ""
-        fi
+    if command -v python3 &>/dev/null; then
+        _item "Python:"
+        python3 --version
+        echo ""
+    fi
 
-        if command -v docker &>/dev/null; then
-            echo "Docker:"
-            docker --version
-            echo ""
-        fi
+    if command -v docker &>/dev/null; then
+        _item "Docker:"
+        docker --version
+        echo ""
+    fi
 
-        if sudo test -s "$TARGET_USER_HOME/.nvm/nvm.sh"; then
-            echo "Node.js & NPM (via NVM):"
-            sudo -u "$TARGET_USER" bash -c "$_nvm_cmd; echo -n 'Node: '; node -v; echo -n 'NPM:  '; npm -v" 2>/dev/null ||
-                echo "  (run as $TARGET_USER with NVM loaded)"
-            echo ""
-        fi
+    if sudo test -s "$TARGET_USER_HOME/.nvm/nvm.sh"; then
+        _item "Node.js & NPM (via NVM):"
+        sudo -u "$TARGET_USER" bash -c "$nvm_cmd; echo -n 'Node: '; node -v; echo -n 'NPM:  '; npm -v" 2>/dev/null \
+            || echo "  (run as $TARGET_USER with NVM loaded)"
+        echo ""
+    fi
 
-        if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
-            echo "Homebrew:"
-            sudo -u "$TARGET_USER" bash -c "$_brew_cmd; brew --version | head -n 1" 2>/dev/null ||
-                echo "  Installed (source $TARGET_USER_HOME/.zshrc to activate)"
-            echo ""
-        fi
+    if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
+        _item "Homebrew:"
+        sudo -u "$TARGET_USER" bash -c "$brew_cmd; brew --version | head -n 1" 2>/dev/null \
+            || echo "  Installed (source $TARGET_USER_HOME/.zshrc to activate)"
+        echo ""
+    fi
 
-        if command -v gemini &>/dev/null; then
-            echo "Google Gemini CLI:"
-            echo "Installed at $(command -v gemini)"
-            echo ""
-        fi
+    if command -v gemini &>/dev/null; then
+        _item "Google Gemini CLI:"
+        echo "Installed at $(command -v gemini)"
+        echo ""
+    fi
 
-        if command -v nvidia-smi &>/dev/null; then
-            echo "NVIDIA GPU Driver:"
-            nvidia-smi --query-gpu=driver_version,name --format=csv,noheader 2>/dev/null || nvidia-smi
-            nvidia-smi -q 2>/dev/null | grep -i "license" || true
-            echo ""
-        fi
+    if command -v nvidia-smi &>/dev/null; then
+        _item "NVIDIA GPU Driver:"
+        nvidia-smi --query-gpu=driver_version,name --format=csv,noheader 2>/dev/null || nvidia-smi
+        nvidia-smi -q 2>/dev/null | grep -i "license" || true
+        echo ""
+    fi
 
-        if command -v btop &>/dev/null; then
-            echo "btop (System Monitor):"
-            btop --version | head -n 1
-            echo ""
-        fi
+    if command -v btop &>/dev/null; then
+        _item "btop (System Monitor):"
+        btop --version | head -n 1
+        echo ""
+    fi
 
-        if command -v nvtop &>/dev/null; then
-            echo "nvtop (GPU Monitor):"
-            nvtop --version
-            echo ""
-        fi
+    if command -v nvtop &>/dev/null; then
+        _item "nvtop (GPU Monitor):"
+        nvtop --version
+        echo ""
+    fi
 
-        if command -v gcc &>/dev/null; then
-            echo "gcc Compiler:"
-            gcc --version | head -n 1
-            echo ""
-        fi
+    if command -v gcc &>/dev/null; then
+        _item "gcc Compiler:"
+        gcc --version | head -n 1
+        echo ""
+    fi
 
-        if command -v nvcc &>/dev/null; then
-            echo "CUDA:"
-            nvcc --version
-            echo ""
-        fi
+    if command -v nvcc &>/dev/null; then
+        _item "CUDA:"
+        nvcc --version
+        echo ""
+    fi
 
-        if ensure_nvidia_ctk_for_current_shell >/dev/null 2>&1; then
-            echo "NVIDIA Container Toolkit:"
-            nvidia-ctk --version 2>/dev/null || echo "Installed"
-            echo ""
-        fi
+    if ensure_nvidia_ctk_for_current_shell >/dev/null 2>&1; then
+        _item "NVIDIA Container Toolkit:"
+        nvidia-ctk --version 2>/dev/null || echo "Installed"
+        echo ""
+    fi
 
-        if has_cudnn_available; then
-            echo "cuDNN Library:"
-            dpkg -l 2>/dev/null | grep -E 'cudnn|libcudnn' || true
-            echo ""
-        fi
+    if has_cudnn_available; then
+        _item "cuDNN Library:"
+        dpkg -l 2>/dev/null | grep -E 'cudnn|libcudnn' || true
+        echo ""
+    fi
 
-        if command -v ollama &>/dev/null; then
-            echo "Ollama:"
-            ollama --version 2>/dev/null || echo "Installed"
+    if command -v ollama &>/dev/null; then
+        _item "Ollama:"
+        ollama --version 2>/dev/null || echo "Installed"
+        if [[ $is_file -eq 1 ]]; then
             echo "API URL: http://127.0.0.1:11434"
             echo "Commands:"
             echo "  sudo systemctl start ollama"
             echo "  sudo systemctl stop  ollama"
-            echo ""
         fi
+        echo ""
+    fi
 
-        if command -v llama-server &>/dev/null; then
-            echo "llama.cpp:"
-            echo "llama-server installed at $(command -v llama-server)"
-            echo ""
-            echo "  -> Service commands:"
-            echo "     sudo systemctl start   llama-server"
-            echo "     sudo systemctl stop    llama-server"
-            echo "     sudo systemctl restart llama-server"
-            echo "     sudo systemctl status  llama-server"
-            echo "     sudo journalctl -u llama-server -f   # follow live logs"
-            if systemctl is-active --quiet llama-server 2>/dev/null; then
-                local _exec_line _llama_args _model_path _model_name _ctx_val _ctk_val _ngl_val
-                _exec_line=$(sudo grep -m1 '^ExecStart=' /etc/systemd/system/llama-server.service 2>/dev/null || true)
-                _llama_args=$(echo "$_exec_line" | grep -oE 'llama-server.*' | head -1 || true)
-                _model_path=$(echo "$_llama_args" | grep -oE -- '--model [^[:space:]]+' | awk '{print $2}' || true)
-                [[ -z "$_model_path" ]] && _model_path=$(echo "$_llama_args" | grep -oE -- '--hf-file [^[:space:]]+' | awk '{print $2}' || true)
-                [[ -n "$_model_path" ]] && _model_name=$(basename "$_model_path" 2>/dev/null || true)
-                _ctx_val=$(echo "$_llama_args" | grep -oE -- '-c [0-9]+' | awk '{print $2}' || true)
-                _ctk_val=$(echo "$_llama_args" | grep -oE -- '-ctk [^[:space:]]+' | awk '{print $2}' || true)
-                _ngl_val=$(echo "$_llama_args" | grep -oE -- '-ngl [0-9]+' | awk '{print $2}' || true)
+    # ── llama.cpp ────────────────────────────────────────────────────
+    if command -v llama-server &>/dev/null; then
+        _item "llama.cpp:"
+        echo "llama-server installed at $(command -v llama-server)"
+        echo ""
+        _subheader "Service commands:"
+        echo "     sudo systemctl start   llama-server"
+        echo "     sudo systemctl stop    llama-server"
+        echo "     sudo systemctl restart llama-server"
+        echo "     sudo systemctl status  llama-server"
+        echo "     sudo journalctl -u llama-server -f   # follow live logs"
+
+        if systemctl is-active --quiet llama-server 2>/dev/null; then
+            # File-only: extract runtime params from the systemd unit
+            if [[ $is_file -eq 1 ]]; then
+                local exec_line llama_args model_path model_name ctx_val ctk_val ngl_val
+                exec_line=$(sudo grep -m1 '^ExecStart=' /etc/systemd/system/llama-server.service 2>/dev/null || true)
+                llama_args=$(echo "$exec_line" | grep -oE 'llama-server.*' | head -1 || true)
+                model_path=$(echo "$llama_args" | grep -oE -- '--model [^[:space:]]+' | awk '{print $2}' || true)
+                [[ -z "$model_path" ]] && model_path=$(echo "$llama_args" | grep -oE -- '--hf-file [^[:space:]]+' | awk '{print $2}' || true)
+                [[ -n "$model_path" ]] && model_name=$(basename "$model_path" 2>/dev/null || true)
+                ctx_val=$(echo "$llama_args" | grep -oE -- '-c [0-9]+' | awk '{print $2}' || true)
+                ctk_val=$(echo "$llama_args" | grep -oE -- '-ctk [^[:space:]]+' | awk '{print $2}' || true)
+                ngl_val=$(echo "$llama_args" | grep -oE -- '-ngl [0-9]+' | awk '{print $2}' || true)
                 echo ""
-                echo "  Running model: ${_model_name:-unknown}"
-                [[ -n "$_ctx_val" ]] && echo "  Context:       $_ctx_val tokens"
-                [[ -n "$_ctk_val" ]] && echo "  KV cache type: $_ctk_val"
-                [[ -n "$_ngl_val" ]] && echo "  GPU layers:    $_ngl_val"
+                echo "  Running model: ${model_name:-unknown}"
+                [[ -n "$ctx_val" ]] && echo "  Context:       $ctx_val tokens"
+                [[ -n "$ctk_val" ]] && echo "  KV cache type: $ctk_val"
+                [[ -n "$ngl_val" ]] && echo "  GPU layers:    $ngl_val"
                 echo "  API URL:       http://127.0.0.1:8080/v1"
                 echo "  API key:       sk-llamacpp"
-                echo ""
-                echo "  -> To test your live API server from the terminal, run:"
-                cat <<'CURLEOF'
+            fi
+
+            echo ""
+            _subheader "To test your live API server from the terminal, run:"
+            cat <<'CURLEOF'
      curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer sk-llamacpp" \
@@ -4710,156 +4489,235 @@ save_ai_settings_file() {
          "max_tokens": 150
        }' | jq -r '.choices[0].message.content'
 CURLEOF
-            fi
-            echo ""
+        fi
+        echo ""
+    fi
+
+    # ── Open-WebUI ───────────────────────────────────────────────────
+    if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^open-webui$'; then
+        _item "Open-WebUI (Docker):"
+        local webui_status
+        webui_status=$(sudo docker inspect -f '{{.State.Status}}' open-webui 2>/dev/null || echo "unknown")
+        echo "Status: $webui_status"
+        if command -v llama-server &>/dev/null; then
+            _subheader "How to connect Open-WebUI to llama.cpp:"
+            echo "     1. Open WebUI in your browser (e.g., http://localhost:8081)"
+            echo "     2. Go to Profile (bottom left) -> Settings -> Connections"
+            echo "     3. Under 'OpenAI API', verify the URL is 'http://127.0.0.1:8080/v1' and Key is 'sk-llamacpp'"
+            echo "     4. Click the 'Verify Connection' icon. Your model should automatically load!"
+        fi
+        echo ""
+    fi
+
+    # ── LibreChat ────────────────────────────────────────────────────
+    if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qi 'librechat'; then
+        _item "LibreChat (Docker):"
+        local lc_status lc_port="${LIBRECHAT_PORT:-3080}"
+        lc_status=$(sudo docker inspect -f '{{.State.Status}}' LibreChat-api 2>/dev/null || echo "Running")
+        echo "Status: $lc_status"
+
+        if sudo test -f "$TARGET_USER_HOME/LibreChat/.env"; then
+            local real_port
+            real_port=$(sudo grep "^PORT=" "$TARGET_USER_HOME/LibreChat/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '\r')
+            [[ -n "$real_port" ]] && lc_port="$real_port"
         fi
 
-        if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^open-webui$'; then
-            echo "Open-WebUI (Docker):"
-            local _webui_status
-            _webui_status=$(sudo docker inspect -f '{{.State.Status}}' open-webui 2>/dev/null || echo "unknown")
-            echo "Status: $_webui_status"
-            if command -v llama-server &>/dev/null; then
-                echo "  -> How to connect Open-WebUI to llama.cpp:"
-                echo "     1. Open WebUI in your browser (e.g., http://localhost:8081)"
-                echo "     2. Go to Profile (bottom left) -> Settings -> Connections"
-                echo "     3. Under 'OpenAI API', verify URL is 'http://127.0.0.1:8080/v1' and Key is 'sk-llamacpp'"
-                echo "     4. Click the 'Verify Connection' icon. Your model should automatically load!"
-            fi
-            echo ""
-        fi
-
-        if sudo docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qi 'librechat'; then
-            echo "LibreChat (Docker):"
-            local _lc_status _lc_port="${LIBRECHAT_PORT:-3080}"
-            _lc_status=$(sudo docker inspect -f '{{.State.Status}}' LibreChat-api 2>/dev/null || echo "Running")
-            echo "Status: $_lc_status"
-            if sudo test -f "$TARGET_USER_HOME/LibreChat/.env"; then
-                local _rp
-                _rp=$(sudo grep "^PORT=" "$TARGET_USER_HOME/LibreChat/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '\r')
-                [[ -n "$_rp" ]] && _lc_port="$_rp"
-            fi
-            echo "  -> How to access LibreChat:"
-            echo "     URL: http://${_lan_ip:-localhost}:${_lc_port}"
+        _subheader "How to access LibreChat:"
+        if [[ $is_file -eq 1 ]]; then
+            echo "     URL: http://${lan_ip:-localhost}:${lc_port}"
             echo "     1. Open LibreChat in your browser"
             echo "     2. Click 'Register' to create your admin account."
             echo "  Commands:"
             echo "     cd $TARGET_USER_HOME/LibreChat && docker compose up -d    # start"
             echo "     cd $TARGET_USER_HOME/LibreChat && docker compose down      # stop"
-            echo ""
-        fi
-
-        # --- OpenClaw ---
-        local _oc_bin
-        _oc_bin=$(sudo -u "$TARGET_USER" bash -c \
-            "$_nvm_cmd; command -v openclaw 2>/dev/null || true" 2>/dev/null || true)
-        if [[ -n "$_oc_bin" ]] || sudo test -f "$TARGET_USER_HOME/.local/bin/openclaw"; then
-            echo "OpenClaw:"
-            sudo -u "$TARGET_USER" bash -c \
-                "$_nvm_cmd; openclaw --version 2>/dev/null || echo 'Installed'" 2>/dev/null || echo "Installed"
-
-            if sudo test -f "$TARGET_USER_HOME/.openclaw/openclaw.json"; then
-                local _oc_port _oc_bind
-                _oc_port=$(sudo jq -r '.gateway.port // 18789' "$TARGET_USER_HOME/.openclaw/openclaw.json" 2>/dev/null || echo "18789")
-                _oc_bind=$(sudo jq -r '.gateway.bind // "loopback"' "$TARGET_USER_HOME/.openclaw/openclaw.json" 2>/dev/null || echo "loopback")
-                echo "  Port:   $_oc_port"
-                echo "  Bind:   $_oc_bind"
-                echo "  Config: $TARGET_USER_HOME/.openclaw/openclaw.json"
-                echo ""
-                echo "  -> Service commands (as user $TARGET_USER):"
-                echo "     systemctl --user start  openclaw-gateway"
-                echo "     systemctl --user stop   openclaw-gateway"
-                echo "     systemctl --user status openclaw-gateway"
-                echo ""
-                echo "  -> Control UI access:"
-                echo "     Direct (LAN): http://${_lan_ip:-<server-ip>}:${_oc_port}/"
-                echo ""
-                echo "     SSH tunnel (from a remote machine):"
-                echo "     ssh -L ${_oc_port}:localhost:${_oc_port} [admin-user]@${_lan_ip:-<server-ip>}"
-                echo "     Then open:  http://localhost:${_oc_port}/"
-                echo ""
-                # Try to extract the current session token from today's log
-                local _oc_log _oc_token
-                _oc_log="/tmp/openclaw/openclaw-$(date +%Y-%m-%d).log"
-                _oc_token=""
-                if sudo test -f "$_oc_log" 2>/dev/null; then
-                    _oc_token=$(sudo grep -oE '#token=[a-f0-9]+' "$_oc_log" 2>/dev/null |
-                        tail -1 | sed 's/#token=//' || true)
-                fi
-                if [[ -n "$_oc_token" ]]; then
-                    echo "     Current session token URL:"
-                    echo "     http://localhost:${_oc_port}/#token=${_oc_token}"
-                    echo "     (Token changes on each service restart)"
-                else
-                    echo "     Token: run the command below to get the current token:"
-                fi
-                echo "     sudo -u $TARGET_USER bash -c \\"
-                echo "       'XDG_RUNTIME_DIR=/run/user/\$(id -u $TARGET_USER) openclaw status' | grep -i token"
-            fi
-            echo ""
-        fi
-
-        # --- Hostname resolution ---
-        echo "System Hostname Resolution:"
-        local _hn
-        _hn=$(hostname)
-        if hostname -i &>/dev/null; then
-            echo "  Hostname '$_hn' resolves correctly ($(hostname -i | awk '{print $1}' | head -n 1))."
         else
-            echo "  WARNING: Hostname '$_hn' does not resolve."
-            echo "  Add '127.0.1.1 $_hn' to /etc/hosts to prevent network and sudo delays."
+            echo "     1. Open LibreChat in your browser (e.g., http://localhost:$lc_port)"
+            echo "     2. Click 'Register' to create your admin account."
         fi
         echo ""
+    fi
 
-        if [[ -n "${TARGET_USER:-}" ]]; then
-            echo "Target user: $TARGET_USER  ($TARGET_USER_HOME)"
-            echo ""
-        fi
+    # ── OpenClaw ─────────────────────────────────────────────────────
+    local oc_bin
+    oc_bin=$(sudo -u "$TARGET_USER" bash -c \
+        "$nvm_cmd; command -v openclaw 2>/dev/null || true" 2>/dev/null || true)
+    if [[ -n "$oc_bin" ]] || sudo test -f "$TARGET_USER_HOME/.local/bin/openclaw"; then
+        _item "OpenClaw:"
+        sudo -u "$TARGET_USER" bash -c \
+            "$nvm_cmd; openclaw --version 2>/dev/null || echo 'Installed'" 2>/dev/null || echo "Installed"
 
-        # --- Next steps (mirrors print_final_summary post-install advice) ---
-        local _ua=""
-        if [[ ${#POST_INSTALL_ACTIONS[@]} -gt 0 ]]; then
-            _ua=$(printf '%s\n' "${POST_INSTALL_ACTIONS[@]}" | sort -u | tr '\n' ' ')
-        fi
-        if [[ -n "$_ua" ]]; then
-            echo "===== Next Steps & Important Information ====="
+        # File-only: detailed port / bind / token URL
+        if [[ $is_file -eq 1 ]] && sudo test -f "$TARGET_USER_HOME/.openclaw/openclaw.json"; then
+            local oc_port oc_bind
+            oc_port=$(sudo jq -r '.gateway.port // 18789' "$TARGET_USER_HOME/.openclaw/openclaw.json" 2>/dev/null || echo "18789")
+            oc_bind=$(sudo jq -r '.gateway.bind // "loopback"' "$TARGET_USER_HOME/.openclaw/openclaw.json" 2>/dev/null || echo "loopback")
+            echo "  Port:   $oc_port"
+            echo "  Bind:   $oc_bind"
+            echo "  Config: $TARGET_USER_HOME/.openclaw/openclaw.json"
             echo ""
-            if [[ "$_ua" == *"docker"* ]]; then
-                echo "Docker group change:"
-                echo "  To use Docker without 'sudo' immediately: newgrp docker"
-                echo "  Or log out and back in to apply the group change globally."
-                echo "  Then test: docker run hello-world"
-                echo ""
+            echo "  -> Service commands (as user $TARGET_USER):"
+            echo "     systemctl --user start  openclaw-gateway"
+            echo "     systemctl --user stop   openclaw-gateway"
+            echo "     systemctl --user status openclaw-gateway"
+            echo ""
+            echo "  -> Control UI access:"
+            echo "     Direct (LAN): http://${lan_ip:-<server-ip>}:${oc_port}/"
+            echo ""
+            echo "     SSH tunnel (from a remote machine):"
+            echo "     ssh -L ${oc_port}:localhost:${oc_port} [admin-user]@${lan_ip:-<server-ip>}"
+            echo "     Then open:  http://localhost:${oc_port}/"
+            echo ""
+            # Try to extract the current session token from today's log
+            local oc_log oc_token
+            oc_log="/tmp/openclaw/openclaw-$(date +%Y-%m-%d).log"
+            oc_token=""
+            if sudo test -f "$oc_log" 2>/dev/null; then
+                oc_token=$(sudo grep -oE '#token=[a-f0-9]+' "$oc_log" 2>/dev/null |
+                    tail -1 | sed 's/#token=//' || true)
             fi
-            if [[ "$_ua" == *"zsh"* ]]; then
-                echo "Shell change:"
-                echo "  Your default shell was changed to Zsh."
-                echo "  Open a new terminal, or run: source $TARGET_USER_HOME/.zshrc"
-                echo ""
-            elif [[ "$_ua" == *"nvm"* || "$_ua" == *"brew"* || "$_ua" == *"openclaw"* ]]; then
-                local _rc=""
-                sudo test -f "$TARGET_USER_HOME/.zshrc" && _rc="$TARGET_USER_HOME/.zshrc"
-                sudo test -f "$TARGET_USER_HOME/.bashrc" && [[ -z "$_rc" ]] && _rc="$TARGET_USER_HOME/.bashrc"
-                echo "To activate newly installed commands for '$TARGET_USER' (like nvm, node, gemini), they must either:"
-                echo "  1. Open a NEW terminal window."
-                [[ -n "$_rc" ]] && echo "  2. OR, run the following command in your CURRENT terminal:" &&
-                    echo "source ${_rc}"
-                echo ""
+            if [[ -n "$oc_token" ]]; then
+                echo "     Current session token URL:"
+                echo "     http://localhost:${oc_port}/#token=${oc_token}"
+                echo "     (Token changes on each service restart)"
+            else
+                echo "     Token: run the command below to get the current token:"
             fi
-            if [[ "$_ua" == *"ufw"* ]]; then
-                echo "IMPORTANT: Firewall rules have been configured, but UFW is NOT enabled by default."
-                echo "The following UFW rules have been prepared:"
-                sudo ufw status 2>/dev/null | grep -E 'ALLOW|DENY' | sed 's/^/  - /' || true
-                echo "To enable UFW: sudo ufw enable"
-                echo ""
+            echo "     sudo -u $TARGET_USER bash -c \\"
+            echo "       'XDG_RUNTIME_DIR=/run/user/\$(id -u $TARGET_USER) openclaw status' | grep -i token"
+        fi
+        echo ""
+    fi
+
+    # ── Hostname resolution ──────────────────────────────────────────
+    _item "System Hostname Resolution:"
+    local current_hostname
+    current_hostname=$(hostname)
+    if hostname -i &>/dev/null; then
+        if [[ $is_file -eq 1 ]]; then
+            echo "  Hostname '$current_hostname' resolves correctly ($(hostname -i | awk '{print $1}' | head -n 1))."
+        else
+            print_success "Hostname '$current_hostname' resolves correctly ($(hostname -i | awk '{print $1}' | head -n 1))."
+        fi
+    else
+        if [[ $is_file -eq 1 ]]; then
+            echo "  WARNING: Hostname '$current_hostname' does not resolve."
+            echo "  Add '127.0.1.1 $current_hostname' to /etc/hosts to prevent network and sudo delays."
+        else
+            echo -e "\e[1;31m⚠️  WARNING: Hostname '$current_hostname' does not resolve.\e[0m"
+            echo "   Please add '127.0.1.1 $current_hostname' to your /etc/hosts file to prevent network and sudo delays."
+        fi
+    fi
+    echo ""
+
+    # File-only: target-user footer
+    if [[ $is_file -eq 1 ]] && [[ -n "${TARGET_USER:-}" ]]; then
+        echo "Target user: $TARGET_USER  ($TARGET_USER_HOME)"
+        echo ""
+    fi
+
+    # If no post-install actions recorded, skip Next Steps entirely
+    [[ -z "$unique_actions" ]] && return
+
+    # ── Next Steps & Important Information ───────────────────────────
+    _banner "Next Steps & Important Information"
+    [[ $is_file -eq 1 ]] && echo ""
+
+    local shell_changed=0 path_changed=0
+    [[ "$unique_actions" == *"zsh"* ]] && shell_changed=1
+    if [[ "$unique_actions" == *"nvm"* || "$unique_actions" == *"brew"* \
+         || "$unique_actions" == *"cuda"* || "$unique_actions" == *"openclaw"* ]]; then
+        path_changed=1
+    fi
+
+    if [[ "$unique_actions" == *"docker"* ]]; then
+        if [[ $is_file -eq 1 ]]; then
+            echo "Docker group change:"
+            echo "  To use Docker without 'sudo' immediately: newgrp docker"
+            echo "  Or log out and back in to apply the group change globally."
+            echo "  Then test: docker run hello-world"
+        else
+            print_info "To use Docker without 'sudo' IMMEDIATELY in this terminal, run: newgrp docker"
+            print_info "Otherwise, you must LOG OUT and LOG BACK IN to apply the group change globally."
+            print_info "Then, test your installation with: docker run hello-world"
+        fi
+        echo ""
+    fi
+
+    if [[ $shell_changed -eq 1 ]]; then
+        if [[ $is_file -eq 1 ]]; then
+            echo "Shell change:"
+            echo "  Your default shell was changed to Zsh."
+            echo "  Open a new terminal, or run: source $TARGET_USER_HOME/.zshrc"
+        else
+            echo -e "\e[1;33mYour default shell has been changed to Zsh.\e[0m"
+            echo -e "To start using Zsh and activate all newly installed commands (like nvm, node, gemini), you must either:"
+            echo -e "  1. \e[1;32mOpen a NEW terminal window.\e[0m (Recommended)"
+            echo -e "  2. OR, if you are logged in as '$TARGET_USER', paste the following command into your current terminal:"
+            echo "source $TARGET_USER_HOME/.zshrc"
+        fi
+        echo ""
+    elif [[ $path_changed -eq 1 ]]; then
+        local rc_file=""
+        if sudo test -f "$TARGET_USER_HOME/.zshrc"; then
+            rc_file="$TARGET_USER_HOME/.zshrc"
+        elif sudo test -f "$TARGET_USER_HOME/.bashrc"; then
+            rc_file="$TARGET_USER_HOME/.bashrc"
+        fi
+        if [[ $is_file -eq 1 ]]; then
+            echo "To activate newly installed commands for '$TARGET_USER' (like nvm, node, gemini), they must either:"
+            echo "  1. Open a NEW terminal window."
+            if [[ -n "$rc_file" ]]; then
+                echo "  2. OR, run the following command in your CURRENT terminal:"
+                echo "source ${rc_file}"
             fi
-            if [[ "$_ua" == *"reboot"* ]]; then
-                echo "Reboot recommended:"
-                echo "  A system reboot is recommended to ensure all NVIDIA drivers are loaded correctly."
-                echo ""
+        else
+            echo -e "\e[1;33mTo activate newly installed commands for '$TARGET_USER' (like nvm, node, gemini), they must either:\e[0m"
+            echo -e "  1. \e[1;32mOpen a NEW terminal window.\e[0m"
+            if [[ -n "$rc_file" ]]; then
+                echo -e "  2. OR, run the following command in your CURRENT terminal:"
+                echo "source ${rc_file}"
             fi
         fi
-    } >"$out_file"
+        echo ""
+    fi
+
+    # File-only: UFW status
+    if [[ $is_file -eq 1 && "$unique_actions" == *"ufw"* ]]; then
+        echo "IMPORTANT: Firewall rules have been configured, but UFW is NOT enabled by default."
+        echo "The following UFW rules have been prepared:"
+        sudo ufw status 2>/dev/null | grep -E 'ALLOW|DENY' | sed 's/^/  - /' || true
+        echo "To enable UFW: sudo ufw enable"
+        echo ""
+    fi
+
+    if [[ "$unique_actions" == *"reboot"* ]]; then
+        if [[ $is_file -eq 1 ]]; then
+            echo "Reboot recommended:"
+            echo "  A system reboot is recommended to ensure all NVIDIA drivers are loaded correctly."
+            echo ""
+        else
+            print_info "A system reboot is highly recommended to ensure all NVIDIA drivers are loaded correctly."
+        fi
+    fi
+}
+
+print_final_summary() {
+    # Ensure newly installed binaries are in the script's PATH for verification
+    [ -d "/usr/local/cuda/bin" ] && export PATH="/usr/local/cuda/bin:$PATH"
+    _render_summary "terminal"
+    # Save on-disk summary only when something was installed/repaired (matches
+    # the pre-refactor behaviour — the old print_final_summary returned early
+    # before reaching save_ai_settings_file when POST_INSTALL_ACTIONS was empty).
+    if [[ ${#POST_INSTALL_ACTIONS[@]} -gt 0 ]]; then
+        save_ai_settings_file
+    fi
+}
+
+# Write a clean, plain-text AI-settings summary to ~/AI-settings.txt
+# Called from print_final_summary (after install) and the 's' goal-menu key.
+save_ai_settings_file() {
+    local out_file="$HOME/AI-settings.txt"
+    _render_summary "file" >"$out_file"
     print_success "Settings saved → $out_file"
 }
 

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -1472,25 +1472,17 @@ install_cuda_toolkit() {
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y install cuda-toolkit
 
-    # The CUDA toolkit installs to /usr/local/cuda, which is not always in the PATH.
-    # We will add it idempotently to the user's shell configuration.
-    print_info "Verifying CUDA path in shell configuration..."
-    local cuda_env_str
-    cuda_env_str=$(
-        cat <<'EOF'
+    # The CUDA toolkit installs to /usr/local/cuda, which is not in the default PATH.
+    # Write to /etc/profile.d/ so every user (sudo caller, target user, future users)
+    # gets CUDA in PATH automatically on login — no per-user RC patching needed.
+    print_info "Writing CUDA path to /etc/profile.d/cuda.sh (system-wide)..."
+    sudo tee /etc/profile.d/cuda.sh >/dev/null <<'CUDAEOF'
+# Added by ubuntu-prep-setup.sh — CUDA Toolkit system-wide PATH
 export CUDA_HOME="/usr/local/cuda"
-export PATH="$CUDA_HOME/bin:$PATH"
-export LD_LIBRARY_PATH="$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
-EOF
-    )
-    if sudo test -f "$TARGET_USER_HOME/.zshrc" && ! sudo grep -q 'CUDA_HOME' "$TARGET_USER_HOME/.zshrc"; then
-        print_info "Adding CUDA path to ~/.zshrc"
-        echo -e "\n# Add NVIDIA CUDA Toolkit to path\n${cuda_env_str}" | sudo tee -a "$TARGET_USER_HOME/.zshrc" >/dev/null
-    fi
-    if sudo test -f "$TARGET_USER_HOME/.bashrc" && ! sudo grep -q 'CUDA_HOME' "$TARGET_USER_HOME/.bashrc"; then
-        print_info "Adding CUDA path to ~/.bashrc"
-        echo -e "\n# Add NVIDIA CUDA Toolkit to path\n${cuda_env_str}" | sudo tee -a "$TARGET_USER_HOME/.bashrc" >/dev/null
-    fi
+export PATH="$CUDA_HOME/bin${PATH:+:$PATH}"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+CUDAEOF
+    sudo chmod 644 /etc/profile.d/cuda.sh
 
     export CUDA_HOME="/usr/local/cuda"
     export PATH="$CUDA_HOME/bin:$PATH"

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -1499,7 +1499,11 @@ install_container_toolkit() {
     # and talks to the GPU. If the kernel module isn't loaded it will fail.
     if ! require_nvidia_module_loaded "NVIDIA Container Toolkit"; then
         echo "⚠️  Skipping Container Toolkit install — reboot first, then re-run."
-        record_component_outcome "NVIDIA Container Toolkit" "$CONTAINER_TOOLKIT_COMPONENT_ACTION" "failed"
+        # Container Toolkit has no repair path (it's a dependency installed inline
+        # from the main install flow), so the action is always "install". There is
+        # no CONTAINER_TOOLKIT_COMPONENT_ACTION global — earlier versions of this
+        # line referenced an undefined variable that silently expanded to "".
+        record_component_outcome "NVIDIA Container Toolkit" "install" "failed"
         return 1
     fi
 

--- a/ubuntu-prep-setup.sh
+++ b/ubuntu-prep-setup.sh
@@ -243,9 +243,9 @@ ask_yn() {
     while true; do
         read -r -p "$prompt" reply
         case "${reply:-$default}" in
-            y|Y) return 0 ;;
-            n|N) return 1 ;;
-            *)   echo "  Please enter y or n." ;;
+            y | Y) return 0 ;;
+            n | N) return 1 ;;
+            *) echo "  Please enter y or n." ;;
         esac
     done
 }
@@ -5016,7 +5016,6 @@ main() {
         echo -e "  Target user:         $TARGET_USER"
         echo ""
         detect_gpu # re-detect GPU (now loaded after reboot)
-        setup_env_secrets
         # Jump straight to installation — skip all menus
     else
         determine_target_user
@@ -5464,8 +5463,11 @@ main() {
         fi
     fi # end: if [[ "$RESUME_MODE" == false ]]
 
-    # Configure API keys after menu selection, before installation tasks begin
-    setup_env_secrets
+    # Configure API keys after menu selection, before installation tasks begin.
+    # Skipped on resume — keys were already configured in the original run.
+    if [[ "$RESUME_MODE" == false ]]; then
+        setup_env_secrets
+    fi
 
     echo -e "\n--- Starting Installation ---"
     local something_installed=0


### PR DESCRIPTION
## Summary

End-to-end validated on Ubuntu 24.04 + NVIDIA RTXA5000-24Q (PCIe passthrough):
**llama.cpp + OpenWebUI + LibreChat + OpenClaw all working, surviving reboot.**

### What's in this branch (11 commits)

**Infrastructure**
- Add BATS test suite (218 tests) — protects all bash refactors going forward
- Replace systemd auto-resume with manual re-run (simpler, more reliable)

**Bug fixes — install correctness**
- Fix `install_cudnn`: rewrite to use NVIDIA's official local repo `.deb` installer (v9.21.0). Previous approach tried `cudnn9-cuda-13` from the CUDA toolkit repo which does not carry cuDNN packages
- Fix CUDA PATH missing for non-target users — write `/etc/profile.d/cuda.sh` (system-wide) instead of patching per-user `.bashrc`
- Fix undefined `CONTAINER_TOOLKIT_COMPONENT_ACTION` variable in container-toolkit install

**Bug fixes — runtime**
- Fix resume state file unreadable by non-root user (`source <(sudo cat ...)`)
- Fix `setup_env_secrets` called twice on resume (API keys prompted twice)
- Add `ask_yn()` helper — validate all y/N prompts, loop on invalid input
- Clarify user-selection menu text (sudo user vs dedicated standard user)

**OpenClaw fixes**
- Auto-configure llama.cpp provider if `openclaw onboard` silently skips it (TTY bug in `su -c` pipe)
- Patch systemd service ExecStart port — `openclaw daemon install` hardcodes `--port 18789` regardless of `gateway.port` in JSON
- Fix context-window jq path: `.providers` → `.models.providers`

## Test plan

- [x] Bash syntax: `bash -n ubuntu-prep-setup.sh`
- [x] Shellcheck: 0 warnings
- [x] BATS: 218/218 passing
- [x] Live install on Ubuntu 24.04 + NVIDIA RTXA5000-24Q
- [x] cuDNN 9.21.0 installed and ldconfig-registered
- [x] CUDA 13 `nvcc` in PATH for all users after login
- [x] llama-server service survives reboot
- [x] OpenWebUI + LibreChat containers survive reboot
- [x] OpenClaw connected to llama.cpp, Control UI accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)