### PR TITLE
Add llama-reconfigure.sh — menu-driven editor for llama-server.service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,14 @@ jobs:
           sudo apt-get install -y shellcheck bats
 
       - name: Shellcheck
-        run: shellcheck --severity=warning ubuntu-prep-setup.sh
+        run: |
+          shellcheck --severity=warning ubuntu-prep-setup.sh
+          [ -f llama-reconfigure.sh ] && shellcheck --severity=warning llama-reconfigure.sh || true
 
       - name: Bash syntax
-        run: bash -n ubuntu-prep-setup.sh
+        run: |
+          bash -n ubuntu-prep-setup.sh
+          [ -f llama-reconfigure.sh ] && bash -n llama-reconfigure.sh || true
 
       - name: Bats test suite
         run: bats tests/
@@ -50,7 +54,10 @@ jobs:
 
       - name: Generate SHA256SUMS
         run: |
-          sha256sum ubuntu-prep-setup.sh > SHA256SUMS
+          {
+            sha256sum ubuntu-prep-setup.sh
+            [ -f llama-reconfigure.sh ] && sha256sum llama-reconfigure.sh
+          } > SHA256SUMS
           cat SHA256SUMS
 
       - name: Extract release notes from CHANGELOG
@@ -77,8 +84,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Build the asset list dynamically so old tags (pre-llama-reconfigure)
+          # don't fail the release step.
+          ASSETS=(ubuntu-prep-setup.sh SHA256SUMS)
+          [ -f llama-reconfigure.sh ] && ASSETS+=(llama-reconfigure.sh)
+
           gh release create "${GITHUB_REF_NAME}" \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${GITHUB_REF_NAME}" \
             --notes-file RELEASE_NOTES.md \
-            ubuntu-prep-setup.sh SHA256SUMS
+            "${ASSETS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to `ubuntu-prep-setup.sh` are tracked here. Format follows
 
 ## [Unreleased]
 
+### Added
+- **`llama-reconfigure.sh`** — standalone, menu-driven editor for an
+  installed `llama-server.service`. Parses the existing `ExecStart`
+  in-place (preserves hand edits), lets the user change any of:
+  model (HF slug `org/repo:file.gguf` or local path), context size,
+  `-ngl`, KV cache quant, `--flash-attn`, listen host/port, `--mlock`,
+  `--fit` / `--fit-ctx`, or raw args. On apply: downloads the new
+  model (blocking, with curl progress bar), snapshots the current unit
+  to `.bak`, writes the new unit, `daemon-reload`, restart, polls
+  `is-active` for 10s, tails `journalctl` on failure, and offers
+  `--rollback`. Flags (`--model`, `--context`, …) jump straight into
+  specific editors for scripting. Does NOT modify `ubuntu-prep-setup.sh`
+  — install `llama-reconfigure` independently once the base installer
+  has set up llama.cpp.
+- 15 new bats tests pinning the parser, serializer, round-trip, and
+  the single-quote validator (total: 235).
+
 ## [1.0.1] — 2026-04-19
 
 Second-pass code review hardening. All 15 findings from an independent review

--- a/llama-reconfigure.sh
+++ b/llama-reconfigure.sh
@@ -1,0 +1,550 @@
+#!/bin/bash
+#
+# llama-reconfigure — menu-driven editor for an installed llama-server.service
+#
+# Lets you change the model and/or runtime flags on a running llama.cpp
+# systemd service, then safely swaps the unit and restarts. Parses the
+# existing ExecStart line in-place so hand edits and install-time choices
+# are preserved; only the flags you touch change.
+#
+# Part of the ubuntu-prep project:
+#   https://github.com/chsbusch-dot/Ubuntu-AI-Tools-Install
+#
+# This is a standalone script — it does NOT require ubuntu-prep-setup.sh
+# to be present. Install once, then re-run whenever you want to retune.
+
+set -euo pipefail
+
+LLAMA_RECONFIGURE_VERSION="0.1.0"
+
+UNIT_FILE="/etc/systemd/system/llama-server.service"
+BAK_FILE="${UNIT_FILE}.bak"
+
+# ─── Colours ───────────────────────────────────────────────────────────
+C_RESET=$'\e[0m'; C_BOLD=$'\e[1m'
+C_RED=$'\e[31m'; C_GREEN=$'\e[32m'; C_YELLOW=$'\e[33m'
+C_CYAN=$'\e[36m'
+
+info()    { printf '%s➜%s %s\n'   "$C_CYAN"   "$C_RESET" "$*"; }
+ok()      { printf '%s✓%s %s\n'   "$C_GREEN"  "$C_RESET" "$*"; }
+warn()    { printf '%s⚠%s %s\n'   "$C_YELLOW" "$C_RESET" "$*" >&2; }
+die()     { printf '%s✗%s %s\n'   "$C_RED"    "$C_RESET" "$*" >&2; exit 1; }
+
+# ─── Usage ─────────────────────────────────────────────────────────────
+show_usage() {
+    cat <<USAGE
+llama-reconfigure ${LLAMA_RECONFIGURE_VERSION} — edit an installed llama-server.service
+
+Usage: llama-reconfigure [OPTION]
+
+Runs an interactive menu by default. Each --flag below jumps straight
+into that editor; after applying you're returned to the main menu or
+you can cancel.
+
+EDITOR JUMPS
+  --model       HuggingFace repo/file (e.g. org/repo:file.gguf) or a local path
+  --context     Context size (-c)
+  --ngl         GPU layer offload (-ngl)
+  --cache       KV cache quant (-ctk / -ctv)
+  --flash       Toggle --flash-attn
+  --listen      Listen address (--host / --port)
+  --mlock       Toggle --mlock
+  --fit         Auto-fit (--fit / --fit-ctx)
+  --raw         Raw ExecStart arg-string editor (advanced)
+
+READ-ONLY / MAINTENANCE
+  --show        Print the parsed current configuration and exit
+  --dry-run     Walk through the menu, print the would-be ExecStart, write nothing
+  --rollback    Restore llama-server.service from the last .bak and restart
+
+  --version, -V Print version and exit
+  --help, -h    Show this help and exit
+
+REQUIRES
+  - /etc/systemd/system/llama-server.service (run ubuntu-prep-setup.sh first)
+  - sudo (the script re-execs itself with sudo if run as a normal user)
+
+SAFETY
+  The current unit is copied to ${BAK_FILE} before every change.
+  Use --rollback to restore it if something fails.
+USAGE
+}
+
+# ─── Preconditions ─────────────────────────────────────────────────────
+
+require_unit_file() {
+    [[ -f "$UNIT_FILE" ]] || die "No llama-server service found at ${UNIT_FILE}. Run ubuntu-prep-setup.sh first."
+}
+
+ensure_root() {
+    # Re-exec with sudo, preserving env so HF_TOKEN from the user's
+    # ~/.env.secrets is available if something downstream sources it.
+    if [[ $EUID -ne 0 ]]; then
+        exec sudo --preserve-env=HF_TOKEN -- bash "$0" "$@"
+    fi
+}
+
+# ─── Parser ────────────────────────────────────────────────────────────
+#
+# Populates globals from the current unit file:
+#   P_EXEC_PREFIX   everything before the llama-server arg list
+#   P_EXEC_SUFFIX   everything after the llama-server arg list
+#   P_ARG_STRING    the raw arg list (hf-repo/file/model + runtime flags)
+#   P_IS_CUDA       y/n — inferred from LD_LIBRARY_PATH or -ngl
+#   P_MODEL_MODE    hf | local
+#   P_HF_REPO       bartowski/Qwen2.5-…-GGUF       (if HF)
+#   P_HF_FILE       Qwen2.5-…-Q5_K_M.gguf           (if HF)
+#   P_MODEL_PATH    /home/.../model.gguf            (if local)
+#   P_CTX           32768
+#   P_NGL           99
+#   P_CACHE_K       q8_0
+#   P_CACHE_V       q8_0
+#   P_FLASH         on / off
+#   P_HOST          0.0.0.0 / 127.0.0.1 / (unset)
+#   P_PORT          8080
+#   P_MLOCK         y/n
+#   P_FIT           on / off
+#   P_FIT_CTX       65536
+#
+parse_unit_file() {
+    local exec_line
+    exec_line=$(grep -m1 '^ExecStart=' "$UNIT_FILE" || true)
+    [[ -n "$exec_line" ]] || die "No ExecStart= in ${UNIT_FILE}"
+
+    # Split on "llama-server " and ">>" — everything between is the arg list.
+    local after_binary before_redir
+    if [[ "$exec_line" == *"/usr/local/bin/llama-server "* ]]; then
+        P_EXEC_PREFIX="${exec_line%%/usr/local/bin/llama-server *}/usr/local/bin/llama-server "
+        after_binary="${exec_line#*/usr/local/bin/llama-server }"
+    else
+        die "ExecStart does not invoke /usr/local/bin/llama-server — unsupported layout."
+    fi
+
+    if [[ "$after_binary" == *">>"* ]]; then
+        P_ARG_STRING="${after_binary%% >>*}"
+        before_redir=" >>${after_binary#* >>}"
+        P_EXEC_SUFFIX="$before_redir"
+    else
+        # No redirect — arg list runs to end of line (minus any trailing quote)
+        P_ARG_STRING="${after_binary%\'}"
+        P_EXEC_SUFFIX="${after_binary#"$P_ARG_STRING"}"
+    fi
+
+    # CUDA detection: LD_LIBRARY_PATH in Environment= or -ngl in arg string
+    if grep -qE 'LD_LIBRARY_PATH.*cuda' "$UNIT_FILE" 2>/dev/null \
+        || [[ "$P_ARG_STRING" == *"-ngl "* ]]; then
+        P_IS_CUDA="y"
+    else
+        P_IS_CUDA="n"
+    fi
+
+    P_HF_REPO=""; P_HF_FILE=""; P_MODEL_PATH=""; P_MODEL_MODE=""
+    if [[ "$P_ARG_STRING" == *"--hf-repo "* ]]; then
+        P_MODEL_MODE="hf"
+        P_HF_REPO=$(grep -oE -- '--hf-repo [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1)
+        P_HF_FILE=$(grep -oE -- '--hf-file [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1)
+    elif [[ "$P_ARG_STRING" == *"--model "* || "$P_ARG_STRING" == *" -m "* ]]; then
+        P_MODEL_MODE="local"
+        P_MODEL_PATH=$(grep -oE -- '--model [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1)
+        [[ -z "$P_MODEL_PATH" ]] && P_MODEL_PATH=$(grep -oE -- ' -m [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1)
+    fi
+
+    P_CTX=$(grep -oE -- ' -c [0-9]+'    <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    P_NGL=$(grep -oE -- '-ngl [0-9]+'   <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    P_CACHE_K=$(grep -oE -- '-ctk [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    P_CACHE_V=$(grep -oE -- '-ctv [^ ]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    if [[ "$P_ARG_STRING" == *"--flash-attn on"* ]]; then P_FLASH="on"
+    elif [[ "$P_ARG_STRING" == *"--flash-attn off"* ]]; then P_FLASH="off"
+    else P_FLASH=""; fi
+    P_HOST=$(grep -oE -- '--host [^ ]+'  <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    P_PORT=$(grep -oE -- '--port [0-9]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    [[ "$P_ARG_STRING" == *"--mlock"* ]] && P_MLOCK="y" || P_MLOCK="n"
+    P_FIT=$(grep -oE -- '--fit (on|off)' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+    P_FIT_CTX=$(grep -oE -- '--fit-ctx [0-9]+' <<<"$P_ARG_STRING" | awk '{print $2}' | head -1 || true)
+}
+
+# ─── Serializer ────────────────────────────────────────────────────────
+#
+# Builds a fresh arg string from P_* globals. Flag order is fixed so
+# the output is deterministic (easier to diff, easier to test).
+#
+serialize_arg_string() {
+    local out=""
+
+    case "$P_MODEL_MODE" in
+        hf)
+            out+="--hf-repo $P_HF_REPO"
+            [[ -n "$P_HF_FILE" ]] && out+=" --hf-file $P_HF_FILE"
+            ;;
+        local)
+            out+="--model $P_MODEL_PATH"
+            ;;
+    esac
+
+    [[ -n "$P_PORT" ]]    && out+=" --port $P_PORT"
+    [[ "$P_FIT" == "on" ]] && out+=" --fit on --fit-ctx ${P_FIT_CTX:-65536}"
+    if [[ "$P_FIT" != "on" && -n "$P_NGL" ]]; then
+        out+=" -ngl $P_NGL"
+    fi
+    [[ -n "$P_HOST" ]]    && out+=" --host $P_HOST"
+    [[ -n "$P_CTX" ]]     && out+=" -c $P_CTX"
+    [[ -n "$P_CACHE_K" ]] && out+=" -ctk $P_CACHE_K"
+    [[ -n "$P_CACHE_V" ]] && out+=" -ctv $P_CACHE_V"
+    [[ "$P_FLASH" == "on" ]] && out+=" --flash-attn on"
+    [[ "$P_MLOCK" == "y" ]]  && out+=" --mlock"
+
+    printf '%s' "$out"
+}
+
+# Rejects a single quote in the arg string — would break the unit file.
+validate_arg_string() {
+    local s="$1"
+    if [[ "$s" == *\'* ]]; then
+        warn "Arg string contains a single quote; would break the systemd unit. Edit cancelled."
+        return 1
+    fi
+}
+
+# ─── Display ───────────────────────────────────────────────────────────
+
+show_current() {
+    printf '\n%s── Current llama-server configuration ──%s\n' "$C_BOLD$C_CYAN" "$C_RESET"
+    printf '  Unit file    : %s\n' "$UNIT_FILE"
+    printf '  GPU mode     : %s\n' "$([[ "$P_IS_CUDA" == "y" ]] && echo 'CUDA' || echo 'CPU')"
+    case "$P_MODEL_MODE" in
+        hf)    printf '  Model (HF)   : %s:%s\n' "$P_HF_REPO" "${P_HF_FILE:-(repo default)}" ;;
+        local) printf '  Model (file) : %s\n'    "$P_MODEL_PATH" ;;
+        *)     printf '  Model        : %s(not detected — check --raw)%s\n' "$C_YELLOW" "$C_RESET" ;;
+    esac
+    printf '  Context      : %s\n' "${P_CTX:-(unset)}"
+    [[ "$P_IS_CUDA" == "y" ]] && printf '  GPU layers   : %s\n' "${P_NGL:-(unset)}"
+    printf '  KV cache     : K=%s  V=%s\n' "${P_CACHE_K:-f16}" "${P_CACHE_V:-f16}"
+    printf '  Flash attn   : %s\n' "${P_FLASH:-(unset)}"
+    printf '  Listen       : %s:%s\n' "${P_HOST:-127.0.0.1}" "${P_PORT:-8080}"
+    printf '  mlock        : %s\n' "$P_MLOCK"
+    [[ "$P_IS_CUDA" == "y" ]] && printf '  --fit        : %s  (--fit-ctx %s)\n' "${P_FIT:-off}" "${P_FIT_CTX:-unset}"
+    printf '  Service      : %s\n' "$(systemctl is-active llama-server 2>/dev/null || echo 'inactive')"
+    printf '\n'
+}
+
+# ─── Editors ───────────────────────────────────────────────────────────
+# Each editor mutates the P_* state in memory. Apply writes to disk.
+
+edit_context() {
+    local v
+    read -rp "Context size (current: ${P_CTX:-unset}) [blank = keep]: " v
+    [[ -n "$v" ]] || return 0
+    [[ "$v" =~ ^[0-9]+$ ]] || { warn "Not a number."; return 0; }
+    P_CTX="$v"
+}
+
+edit_ngl() {
+    if [[ "$P_IS_CUDA" != "y" ]]; then warn "CPU-only build — -ngl not applicable."; return 0; fi
+    local v
+    read -rp "GPU layers -ngl (current: ${P_NGL:-unset}, 99 = all) [blank = keep]: " v
+    [[ -n "$v" ]] || return 0
+    [[ "$v" =~ ^[0-9]+$ ]] || { warn "Not a number."; return 0; }
+    P_NGL="$v"
+}
+
+edit_cache() {
+    local k v
+    echo "KV cache quant. Options: f16 bf16 q8_0 q4_0 (q8_0 is a good default for CUDA + --flash-attn)"
+    read -rp "  -ctk (current: ${P_CACHE_K:-f16}) [blank = keep]: " k
+    read -rp "  -ctv (current: ${P_CACHE_V:-f16}) [blank = keep]: " v
+    [[ -n "$k" ]] && P_CACHE_K="$k"
+    [[ -n "$v" ]] && P_CACHE_V="$v"
+}
+
+edit_flash() {
+    if [[ "$P_IS_CUDA" != "y" ]]; then warn "--flash-attn is CUDA-only."; return 0; fi
+    case "${P_FLASH:-off}" in
+        on)  P_FLASH="off"; ok "flash-attn → off" ;;
+        *)   P_FLASH="on";  ok "flash-attn → on"  ;;
+    esac
+}
+
+edit_listen() {
+    local h p
+    read -rp "Bind host (current: ${P_HOST:-127.0.0.1}; use 0.0.0.0 to expose on LAN) [blank = keep]: " h
+    read -rp "Port (current: ${P_PORT:-8080}) [blank = keep]: " p
+    [[ -n "$h" ]] && P_HOST="$h"
+    if [[ -n "$p" ]]; then
+        [[ "$p" =~ ^[0-9]+$ ]] && (( p > 0 && p < 65536 )) || { warn "Invalid port."; return 0; }
+        P_PORT="$p"
+    fi
+}
+
+edit_mlock() {
+    case "$P_MLOCK" in
+        y) P_MLOCK="n"; ok "--mlock → off" ;;
+        *) P_MLOCK="y"; ok "--mlock → on"  ;;
+    esac
+}
+
+edit_fit() {
+    if [[ "$P_IS_CUDA" != "y" ]]; then warn "--fit is CUDA-only."; return 0; fi
+    local v c
+    read -rp "Enable --fit (current: ${P_FIT:-off}) [on/off/blank]: " v
+    case "$v" in
+        on)  P_FIT="on"; read -rp "  --fit-ctx (current: ${P_FIT_CTX:-65536}) [blank = keep]: " c
+             [[ -n "$c" && "$c" =~ ^[0-9]+$ ]] && P_FIT_CTX="$c" ;;
+        off) P_FIT="off" ;;
+        "")  return 0 ;;
+        *)   warn "Expected on/off." ;;
+    esac
+}
+
+edit_model() {
+    echo "Model can be an HF slug (org/repo[:file]) or a local .gguf path."
+    case "$P_MODEL_MODE" in
+        hf)    echo "  Current: ${P_HF_REPO}:${P_HF_FILE:-(default)}" ;;
+        local) echo "  Current: $P_MODEL_PATH" ;;
+    esac
+    local v; read -rp "New model [blank = keep]: " v
+    [[ -n "$v" ]] || return 0
+
+    if [[ "$v" == /* ]]; then
+        [[ -r "$v" ]] || { warn "File not readable: $v"; return 0; }
+        P_MODEL_MODE="local"; P_MODEL_PATH="$v"; P_HF_REPO=""; P_HF_FILE=""
+    elif [[ "$v" == *":"* ]]; then
+        P_MODEL_MODE="hf"; P_HF_REPO="${v%%:*}"; P_HF_FILE="${v#*:}"; P_MODEL_PATH=""
+    else
+        P_MODEL_MODE="hf"; P_HF_REPO="$v"; P_HF_FILE=""; P_MODEL_PATH=""
+    fi
+    info "Model queued (download happens at Apply time if not cached)."
+}
+
+edit_raw() {
+    local tmp
+    tmp=$(mktemp -t llama-args.XXXXXX)
+    printf '%s\n' "$P_ARG_STRING" >"$tmp"
+    ${EDITOR:-vi} "$tmp"
+    local new; new=$(<"$tmp"); rm -f "$tmp"
+    # Strip trailing newline
+    new="${new%$'\n'}"
+    validate_arg_string "$new" || return 1
+    P_ARG_STRING="$new"
+    warn "Raw-edit mode bypasses the structured editors — 'Apply' will use this string verbatim."
+    P_RAW_OVERRIDE=1
+}
+
+# ─── HuggingFace download with progress ────────────────────────────────
+#
+# Resolves an HF repo+file to a local cached path, downloading with a
+# visible progress bar if it isn't already cached. Returns the local
+# path via stdout.
+#
+hf_resolve_or_download() {
+    local repo="$1" file="$2" cache_root="${3:-/root/.cache/llama.cpp}"
+    mkdir -p "$cache_root"
+    local dest="$cache_root/${repo//\//_}--${file:-model.gguf}"
+
+    if [[ -f "$dest" ]]; then
+        printf '%s' "$dest"
+        return 0
+    fi
+
+    if [[ -z "$file" ]]; then
+        warn "HF download requires an explicit file (--hf-file). Fetch manually or use org/repo:file.gguf."
+        return 1
+    fi
+
+    local url="https://huggingface.co/${repo}/resolve/main/${file}"
+    info "Downloading ${repo}/${file}…" >&2
+
+    local -a auth=()
+    [[ -n "${HF_TOKEN:-}" ]] && auth=(-H "Authorization: Bearer ${HF_TOKEN}")
+
+    # curl's --progress-bar shows %, size, ETA — better than spinner
+    if ! curl -fL --progress-bar "${auth[@]}" -o "$dest.part" "$url" >&2; then
+        rm -f "$dest.part"
+        warn "Download failed (check repo slug, file name, or HF_TOKEN for gated repos)."
+        return 1
+    fi
+    mv "$dest.part" "$dest"
+    printf '%s' "$dest"
+}
+
+# ─── Apply / rollback ──────────────────────────────────────────────────
+
+apply_changes() {
+    local dry="${1:-}"
+
+    # If model is HF and not yet cached, download it BEFORE touching the unit
+    # so we fail loud without disturbing the running service.
+    if [[ "$P_MODEL_MODE" == "hf" && -n "$P_HF_FILE" ]]; then
+        local resolved; resolved=$(hf_resolve_or_download "$P_HF_REPO" "$P_HF_FILE" "/root/.cache/llama.cpp" || true)
+        if [[ -z "$resolved" ]]; then
+            warn "Model not available — aborting apply."
+            return 1
+        fi
+        ok "Model cached at $resolved"
+        # Keep P_MODEL_MODE=hf so the ExecStart still uses --hf-repo/--hf-file;
+        # llama-server will find the local cache on its own.
+    fi
+
+    local new_args
+    if [[ -n "${P_RAW_OVERRIDE:-}" ]]; then
+        new_args="$P_ARG_STRING"
+    else
+        new_args=$(serialize_arg_string)
+    fi
+    validate_arg_string "$new_args" || return 1
+
+    local new_exec="${P_EXEC_PREFIX}${new_args}${P_EXEC_SUFFIX}"
+    local new_unit; new_unit=$(mktemp -t llama-server-unit.XXXXXX)
+    # Swap the ExecStart= line, keep everything else as-is
+    awk -v newline="$new_exec" '
+        /^ExecStart=/ { print newline; next }
+        { print }
+    ' "$UNIT_FILE" >"$new_unit"
+
+    printf '\n%s── Proposed ExecStart ──%s\n  %s\n\n' "$C_BOLD$C_CYAN" "$C_RESET" "$new_exec"
+
+    if [[ "$dry" == "dry" ]]; then
+        info "(dry run — no changes written)"
+        rm -f "$new_unit"
+        return 0
+    fi
+
+    read -rp "Apply and restart? [y/N]: " ans
+    if [[ "$ans" != [yY] ]]; then
+        rm -f "$new_unit"
+        info "Cancelled — nothing written."
+        return 0
+    fi
+
+    info "Validating unit with systemd-analyze…"
+    if ! systemd-analyze verify "$new_unit" 2>&1 | grep -v '^$' >&2; then
+        : # some versions of systemd-analyze are chatty even on success; don't treat as failure
+    fi
+
+    info "Stopping llama-server…"
+    systemctl stop llama-server 2>/dev/null || true
+
+    info "Backing up current unit → ${BAK_FILE}"
+    cp -a "$UNIT_FILE" "$BAK_FILE"
+
+    info "Installing new unit…"
+    install -m 644 "$new_unit" "$UNIT_FILE"
+    rm -f "$new_unit"
+
+    info "Reloading daemon and restarting…"
+    systemctl daemon-reload
+    if ! systemctl restart llama-server; then
+        warn "Restart failed — inspect with: journalctl -u llama-server -n 100"
+        warn "Rollback available: llama-reconfigure --rollback"
+        return 1
+    fi
+
+    # Poll for up to 10s to catch obvious boot failures
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        if systemctl is-active --quiet llama-server; then
+            ok "llama-server is active (${i}s after restart)."
+            break
+        fi
+        sleep 1
+    done
+
+    if ! systemctl is-active --quiet llama-server; then
+        warn "Service did not come up within 10s. Last log lines:"
+        journalctl -u llama-server -n 30 --no-pager >&2 || true
+        warn "Rollback available: llama-reconfigure --rollback"
+        return 1
+    fi
+
+    ok "Applied. Run 'journalctl -u llama-server -f' to watch startup."
+}
+
+rollback_unit() {
+    [[ -f "$BAK_FILE" ]] || die "No backup at ${BAK_FILE} — nothing to roll back to."
+    info "Stopping llama-server…"
+    systemctl stop llama-server 2>/dev/null || true
+    info "Restoring ${UNIT_FILE} from ${BAK_FILE}"
+    cp -a "$BAK_FILE" "$UNIT_FILE"
+    systemctl daemon-reload
+    systemctl restart llama-server
+    ok "Rolled back. Service status:"
+    systemctl --no-pager status llama-server || true
+}
+
+# ─── Menu ──────────────────────────────────────────────────────────────
+
+main_menu() {
+    while true; do
+        show_current
+        cat <<MENU
+  1) Model          2) Context        3) GPU layers      4) KV cache
+  5) Flash-attn     6) Listen addr    7) mlock           8) --fit
+  9) Raw editor
+  a) Apply and restart     d) Dry-run preview
+  r) Rollback to .bak      q) Quit
+MENU
+        local choice; read -rp "> " choice
+        case "$choice" in
+            1) edit_model   ;;
+            2) edit_context ;;
+            3) edit_ngl     ;;
+            4) edit_cache   ;;
+            5) edit_flash   ;;
+            6) edit_listen  ;;
+            7) edit_mlock   ;;
+            8) edit_fit     ;;
+            9) edit_raw     ;;
+            a|A) apply_changes && return 0 ;;
+            d|D) apply_changes dry ;;
+            r|R) rollback_unit && return 0 ;;
+            q|Q) info "Exit — no changes written."; return 0 ;;
+            *)   warn "Unknown option." ;;
+        esac
+    done
+}
+
+# ─── Entry point ───────────────────────────────────────────────────────
+
+main() {
+    # No args = interactive menu
+    if [[ $# -eq 0 ]]; then
+        ensure_root "$@"
+        require_unit_file
+        parse_unit_file
+        main_menu
+        return
+    fi
+
+    case "$1" in
+        --help|-h)    show_usage; return 0 ;;
+        --version|-V) echo "llama-reconfigure ${LLAMA_RECONFIGURE_VERSION}"; return 0 ;;
+    esac
+
+    ensure_root "$@"
+    require_unit_file
+    parse_unit_file
+
+    case "$1" in
+        --show)       show_current ;;
+        --dry-run)    main_menu; apply_changes dry ;;
+        --rollback)   rollback_unit ;;
+        --model)      edit_model;   apply_changes ;;
+        --context)    edit_context; apply_changes ;;
+        --ngl)        edit_ngl;     apply_changes ;;
+        --cache)      edit_cache;   apply_changes ;;
+        --flash)      edit_flash;   apply_changes ;;
+        --listen)     edit_listen;  apply_changes ;;
+        --mlock)      edit_mlock;   apply_changes ;;
+        --fit)        edit_fit;     apply_changes ;;
+        --raw)        edit_raw && apply_changes ;;
+        *)
+            warn "Unknown option: $1"
+            show_usage
+            return 2
+            ;;
+    esac
+}
+
+# Only run main when executed directly, not when sourced for testing.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/reconfigure.bats
+++ b/tests/reconfigure.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+#
+# Unit tests for llama-reconfigure.sh
+#
+# Covers the parser (parse_unit_file), serializer (serialize_arg_string),
+# and validator (validate_arg_string). These are the pieces that rewrite
+# systemd unit files — getting them wrong means a broken service.
+#
+# Run: bats tests/reconfigure.bats
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/../llama-reconfigure.sh"
+    [ -f "$SCRIPT" ] || skip "llama-reconfigure.sh not found"
+
+    # shellcheck disable=SC1090
+    source "$SCRIPT"
+
+    # Use a per-test unit file in a tmp dir so parse_unit_file has something to read.
+    TEST_DIR=$(mktemp -d)
+    UNIT_FILE="${TEST_DIR}/llama-server.service"
+    BAK_FILE="${UNIT_FILE}.bak"
+}
+
+teardown() {
+    [ -n "${TEST_DIR:-}" ] && rm -rf "$TEST_DIR"
+}
+
+# Writes a minimal but realistic unit file. Callers pass the ExecStart line.
+write_unit() {
+    cat >"$UNIT_FILE" <<EOF
+[Unit]
+Description=Llama.cpp Server
+After=network.target
+
+[Service]
+User=chris
+WorkingDirectory=/home/chris
+Environment="HOME=/home/chris"
+Environment="LLAMA_CACHE=/home/chris/llama.cpp/models"
+Environment="LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+$1
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+# ─── Parser ────────────────────────────────────────────────────────────
+
+@test "parse: minimal HF repo+file, port only" {
+    write_unit "ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo bartowski/Qwen2.5-7B-Instruct-GGUF --hf-file Qwen2.5-7B-Instruct-Q5_K_M.gguf --port 8080 >> \"/home/chris/.cache/llama-server.log\" 2>&1'"
+    parse_unit_file
+    [ "$P_MODEL_MODE" = "hf" ]
+    [ "$P_HF_REPO" = "bartowski/Qwen2.5-7B-Instruct-GGUF" ]
+    [ "$P_HF_FILE" = "Qwen2.5-7B-Instruct-Q5_K_M.gguf" ]
+    [ "$P_PORT" = "8080" ]
+}
+
+@test "parse: full-featured CUDA line" {
+    write_unit "ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo bartowski/Qwen2.5-7B-Instruct-GGUF --hf-file Qwen2.5-7B-Instruct-Q5_K_M.gguf --port 8080 --fit on --fit-ctx 65536 --host 0.0.0.0 -c 32768 -ctk q8_0 -ctv q8_0 --flash-attn on --mlock >> \"/home/chris/.cache/llama-server.log\" 2>&1'"
+    parse_unit_file
+    [ "$P_IS_CUDA" = "y" ]
+    [ "$P_MODEL_MODE" = "hf" ]
+    [ "$P_CTX" = "32768" ]
+    [ "$P_CACHE_K" = "q8_0" ]
+    [ "$P_CACHE_V" = "q8_0" ]
+    [ "$P_FLASH" = "on" ]
+    [ "$P_HOST" = "0.0.0.0" ]
+    [ "$P_PORT" = "8080" ]
+    [ "$P_MLOCK" = "y" ]
+    [ "$P_FIT" = "on" ]
+    [ "$P_FIT_CTX" = "65536" ]
+}
+
+@test "parse: local --model path" {
+    write_unit "ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --model /home/chris/llama.cpp/models/local.gguf --port 8080 -c 4096 >> \"/home/chris/.cache/llama-server.log\" 2>&1'"
+    parse_unit_file
+    [ "$P_MODEL_MODE" = "local" ]
+    [ "$P_MODEL_PATH" = "/home/chris/llama.cpp/models/local.gguf" ]
+    [ "$P_CTX" = "4096" ]
+}
+
+@test "parse: CPU build (no LD_LIBRARY_PATH, no -ngl)" {
+    # Strip the cuda Environment= line by writing a unit file without it.
+    cat >"$UNIT_FILE" <<EOF
+[Unit]
+Description=Llama.cpp Server
+
+[Service]
+User=chris
+ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo x/y --hf-file z.gguf --port 8080 >> "/home/chris/.cache/llama-server.log" 2>&1'
+EOF
+    parse_unit_file
+    [ "$P_IS_CUDA" = "n" ]
+}
+
+@test "parse: CUDA detected from -ngl even without LD_LIBRARY_PATH env" {
+    cat >"$UNIT_FILE" <<EOF
+[Service]
+ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo x/y --hf-file z.gguf --port 8080 -ngl 99 >> "/log" 2>&1'
+EOF
+    parse_unit_file
+    [ "$P_IS_CUDA" = "y" ]
+    [ "$P_NGL" = "99" ]
+}
+
+@test "parse: mlock absent → P_MLOCK=n" {
+    write_unit "ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo x/y --hf-file z.gguf --port 8080 >> \"/log\" 2>&1'"
+    parse_unit_file
+    [ "$P_MLOCK" = "n" ]
+}
+
+@test "parse: unsupported layout dies" {
+    cat >"$UNIT_FILE" <<EOF
+[Service]
+ExecStart=/usr/bin/some-other-binary --flag
+EOF
+    run parse_unit_file
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported layout"* ]]
+}
+
+# ─── Serializer ────────────────────────────────────────────────────────
+
+@test "serialize: minimal HF config" {
+    P_MODEL_MODE="hf"; P_HF_REPO="org/repo"; P_HF_FILE="m.gguf"
+    P_PORT="8080"; P_IS_CUDA="n"
+    P_CTX=""; P_NGL=""; P_CACHE_K=""; P_CACHE_V=""; P_FLASH=""
+    P_HOST=""; P_MLOCK="n"; P_FIT=""; P_FIT_CTX=""
+    result=$(serialize_arg_string)
+    [ "$result" = "--hf-repo org/repo --hf-file m.gguf --port 8080" ]
+}
+
+@test "serialize: full CUDA config is deterministic" {
+    P_MODEL_MODE="hf"; P_HF_REPO="org/repo"; P_HF_FILE="m.gguf"
+    P_PORT="8080"; P_IS_CUDA="y"; P_NGL="99"; P_HOST="0.0.0.0"
+    P_CTX="32768"; P_CACHE_K="q8_0"; P_CACHE_V="q8_0"
+    P_FLASH="on"; P_MLOCK="y"; P_FIT=""; P_FIT_CTX=""
+    result=$(serialize_arg_string)
+    [ "$result" = "--hf-repo org/repo --hf-file m.gguf --port 8080 -ngl 99 --host 0.0.0.0 -c 32768 -ctk q8_0 -ctv q8_0 --flash-attn on --mlock" ]
+}
+
+@test "serialize: --fit on suppresses -ngl (they are mutually exclusive)" {
+    P_MODEL_MODE="hf"; P_HF_REPO="x/y"; P_HF_FILE="z.gguf"
+    P_PORT="8080"; P_NGL="50"; P_FIT="on"; P_FIT_CTX="65536"
+    P_CTX=""; P_CACHE_K=""; P_CACHE_V=""; P_FLASH=""; P_HOST=""; P_MLOCK="n"
+    result=$(serialize_arg_string)
+    [[ "$result" == *"--fit on --fit-ctx 65536"* ]]
+    [[ "$result" != *"-ngl 50"* ]]
+}
+
+@test "serialize: local model uses --model not --hf-repo" {
+    P_MODEL_MODE="local"; P_MODEL_PATH="/m/path.gguf"; P_PORT="8080"
+    P_CTX=""; P_NGL=""; P_CACHE_K=""; P_CACHE_V=""; P_FLASH=""
+    P_HOST=""; P_MLOCK="n"; P_FIT=""; P_FIT_CTX=""
+    P_HF_REPO=""; P_HF_FILE=""
+    result=$(serialize_arg_string)
+    [ "$result" = "--model /m/path.gguf --port 8080" ]
+}
+
+@test "serialize: --fit-ctx defaults to 65536 if unset" {
+    P_MODEL_MODE="hf"; P_HF_REPO="x/y"; P_HF_FILE="z.gguf"
+    P_PORT="8080"; P_FIT="on"; P_FIT_CTX=""
+    P_CTX=""; P_NGL=""; P_CACHE_K=""; P_CACHE_V=""; P_FLASH=""; P_HOST=""; P_MLOCK="n"
+    result=$(serialize_arg_string)
+    [[ "$result" == *"--fit-ctx 65536"* ]]
+}
+
+# ─── Round-trip (parse → serialize → parse) ────────────────────────────
+
+@test "round-trip: parsing our own serializer output is idempotent" {
+    # First round: hand-authored unit
+    write_unit "ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server --hf-repo org/repo --hf-file m.gguf --port 8080 -ngl 99 --host 0.0.0.0 -c 8192 -ctk q8_0 -ctv q8_0 --flash-attn on --mlock >> \"/log\" 2>&1'"
+    parse_unit_file
+
+    # Capture parsed values
+    local saved_ctx="$P_CTX" saved_ngl="$P_NGL" saved_host="$P_HOST" saved_mlock="$P_MLOCK"
+
+    # Serialize and stuff back into a fake unit, then re-parse
+    local new_args
+    new_args=$(serialize_arg_string)
+    cat >"$UNIT_FILE" <<EOF
+[Service]
+Environment="LD_LIBRARY_PATH=/usr/local/cuda/lib64"
+ExecStart=/bin/bash -c 'exec /usr/local/bin/llama-server ${new_args} >> "/log" 2>&1'
+EOF
+    parse_unit_file
+
+    [ "$P_CTX"   = "$saved_ctx"   ]
+    [ "$P_NGL"   = "$saved_ngl"   ]
+    [ "$P_HOST"  = "$saved_host"  ]
+    [ "$P_MLOCK" = "$saved_mlock" ]
+}
+
+# ─── Validator ─────────────────────────────────────────────────────────
+
+@test "validate: clean arg string passes" {
+    run validate_arg_string "--hf-repo org/repo --port 8080 -c 4096"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate: embedded single quote is rejected" {
+    run validate_arg_string "--hf-repo org/repo --port 8080 --extra 'bad'"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
- Standalone companion script to `ubuntu-prep-setup.sh` — lets users swap models or tweak runtime flags on a live `llama-server.service` without re-running the installer.
- **Does not touch `ubuntu-prep-setup.sh`** — shippable on its own once the base installer has set up llama.cpp.
- Menu-driven by default; per-editor flags (`--model`, `--context`, `--ngl`, …) for script-friendly jumps.
- Full bats coverage for parser + serializer + round-trip + validator.

## What it does
Parses the existing `ExecStart=` line in-place, so hand edits and install-time choices are preserved; only the flags the user touches change. Editors cover model (HF `org/repo:file.gguf` or local path), context size, `-ngl`, KV cache quant (`-ctk/-ctv`), `--flash-attn`, listen host/port, `--mlock`, `--fit` / `--fit-ctx`, plus a raw arg editor for anything exotic.

## Safety flow on apply
1. Re-execs with `sudo` if run unprivileged (preserves `HF_TOKEN`).
2. If model is HF and uncached, downloads with a curl progress bar **before** touching the unit — failed download leaves the running service alone.
3. Rejects any arg string containing a single quote (would break the `/bin/bash -c '…'` wrapper).
4. Snapshots `/etc/systemd/system/llama-server.service` → `.service.bak`.
5. `systemd-analyze verify`, stop, install, `daemon-reload`, restart.
6. Polls `is-active` for 10s; tails `journalctl` on failure.
7. One-command rollback: `llama-reconfigure --rollback`.

## What is **not** in this PR (deferred)
- HuggingFace search API integration in the model editor (currently direct-input only — paste `org/repo:file.gguf`). Follow-up PR will wire up the public HF API and a ranked search picker.
- Non-interactive scripted mode (`--set ctx=65536 --apply`). Current `--model` / `--context` / etc. jump into the interactive editor for that one flag; full headless mode is a separate change.

## Install (after this lands + a tag)
\`\`\`bash
curl -fsSL https://github.com/chsbusch-dot/Ubuntu-AI-Tools-Install/releases/latest/download/llama-reconfigure.sh \
  | sudo tee /usr/local/bin/llama-reconfigure > /dev/null && sudo chmod +x /usr/local/bin/llama-reconfigure
\`\`\`
Then: \`sudo llama-reconfigure\`.

## Test plan
- [x] `bash -n llama-reconfigure.sh` — clean
- [x] `shellcheck --severity=warning llama-reconfigure.sh` — clean
- [x] `bats tests/reconfigure.bats` — 15/15
- [x] `bats tests/` full suite — 235/235
- [x] `llama-reconfigure --version` → `llama-reconfigure 0.1.0`
- [x] `llama-reconfigure --help` — prints usage
- [ ] **Needs real-system test**: run `sudo llama-reconfigure --show` on the Ubuntu box (192.168.1.132) against the live service, verify parsed values match the actual unit file.
- [ ] **Needs real-system test**: exercise one editor (e.g. `--context`) end-to-end — confirm new ExecStart writes, service restarts, `is-active` goes green.
- [ ] **Needs real-system test**: `llama-reconfigure --rollback` restores the previous unit cleanly.

## Release note
Will ship as **1.1.0** (new user-visible feature). `llama-reconfigure.sh` has its own `LLAMA_RECONFIGURE_VERSION="0.1.0"` so the two scripts version independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)