### PR TITLE
gpu-mode: add stop-all subcommand to leave the GPU idle

### DIFF
--- a/gpu-mode.sh
+++ b/gpu-mode.sh
@@ -279,6 +279,47 @@ cmd_av() {
     cmd_status
 }
 
+cmd_stop_all() {
+    info "Stopping both GPU stacks (LLM + AV) — leaving the GPU idle…"
+
+    # LLM side first — fastest to stop, frees VRAM immediately.
+    if unit_exists "$LLAMA_SERVICE"; then
+        if llama_is_active; then
+            info "Stopping $LLAMA_SERVICE…"
+            sudo_if_needed systemctl stop "$LLAMA_SERVICE" \
+                || warn "systemctl stop $LLAMA_SERVICE returned non-zero — VRAM may not have been released."
+        else
+            info "$LLAMA_SERVICE already inactive — skipping."
+        fi
+    fi
+
+    # AV side. Same loop shape as cmd_llm's tear-down — keep them in
+    # sync if you touch one.
+    local u
+    while read -r u; do
+        [[ -z "$u" ]] && continue
+        if unit_exists "$u"; then
+            if systemctl is-active --quiet "$u" 2>/dev/null; then
+                info "Stopping $u…"
+                sudo_if_needed systemctl stop "$u" \
+                    || warn "systemctl stop $u returned non-zero — VRAM may not have been released."
+            else
+                info "$u already inactive — skipping."
+            fi
+        fi
+    done < <(av_systemd_units)
+
+    if av_compose_present; then
+        info "Stopping compose AV containers (compose down)…"
+        if ! compose down --remove-orphans; then
+            warn "compose down returned non-zero — some containers may still hold VRAM."
+            warn "Inspect with: docker ps  and  nvidia-smi"
+        fi
+    fi
+
+    cmd_status
+}
+
 cmd_status() {
     printf '\n%s── GPU mode status ──%s\n' "$C_BOLD$C_CYAN" "$C_RESET"
 
@@ -342,6 +383,10 @@ ${C_BOLD}USAGE${C_RESET}
 ${C_BOLD}COMMANDS${C_RESET}
   llm       Stop AV services, start ${LLAMA_SERVICE}. Idempotent.
   av        Stop ${LLAMA_SERVICE}, start AV services. Idempotent.
+  stop-all  Stop both stacks — leave the GPU idle. Idempotent. Use
+            before a reboot, between modes when you don't know which
+            side to switch to next, or to recover from a stuck
+            service (e.g. a NIM stuck in 'activating' restart loop).
   status    Print which side is up + nvidia-smi summary.
   --help    Show this help.
   --version Print version.
@@ -380,6 +425,7 @@ EOF
 case "${1:-}" in
     llm)              cmd_llm ;;
     av)               cmd_av ;;
+    stop-all)         cmd_stop_all ;;
     status)           cmd_status ;;
     -v|--version)     printf 'gpu-mode %s\n' "$GPU_MODE_VERSION" ;;
     -h|--help)        usage ;;


### PR DESCRIPTION
## Summary
\`gpu-mode\` had only \`llm\` and \`av\` — both flip you to one of the two stacks. There was no "stop everything, leave the GPU idle" verb, which is needed for:

- Pre-reboot cleanup so the host comes up in a deterministic state
- Recovering from a stuck service (e.g. a NIM stuck in \`activating (auto-restart)\` after a transient permission failure on \`~/.env.secrets\`)
- Switching modes when you don't know which side to switch to next

## Implementation
\`cmd_stop_all\` mirrors \`cmd_llm\`'s tear-down loop for the AV side and adds a defensive \`systemctl stop\` for the LLM side. Idempotent — if a service is already inactive, it logs "already inactive — skipping" and moves on. Honors the same \`unit_exists\` guard.

```
$ gpu-mode --help
COMMANDS
  llm       Stop AV services, start llama-server. Idempotent.
  av        Stop llama-server, start AV services. Idempotent.
  stop-all  Stop both stacks — leave the GPU idle. Idempotent. Use
            before a reboot, between modes when you don't know which
            side to switch to next, or to recover from a stuck
            service (e.g. a NIM stuck in 'activating' restart loop).
  status    Print which side is up + nvidia-smi summary.
```

## Test plan
- [x] \`bash -n gpu-mode.sh\` clean
- [x] \`./gpu-mode.sh --help\` shows \`stop-all\` in the COMMANDS block
- [ ] Deploy to openclaw and verify \`sudo /usr/local/sbin/gpu-mode-switch stop-all\` brings the cycling \`local-tts-nim\` to a stop cleanly