### PR TITLE
Add IONOS box tools: domain finder + WireGuard exit-node setup

### DIFF
--- a/tools/find_mx_coms.py
+++ b/tools/find_mx_coms.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Find short .com domains whose label ends in a fixed suffix such as "mx".
+
+Designed for searches such as:
+    oakmx.com    (5 letters before .com)
+    homemx.com   (6 letters before .com)
+    housemx.com  (7 letters before .com)
+
+The prefix must be a familiar English word with no common pronunciation
+collision in CMUdict. Results are ranked by familiarity and checked through
+Verisign's .com RDAP service. A 404 means no current registry record was
+returned; always confirm availability and premium pricing at a registrar.
+
+Install:
+    python -m pip install requests wordfreq cmudict
+
+Example:
+    python find_mx_coms.py --lengths 5,6,7 --suffix mx --include busch
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+try:
+    import cmudict
+    from wordfreq import top_n_list, zipf_frequency
+except ImportError as exc:
+    raise SystemExit(
+        "Missing dependencies. Run:\n"
+        "  python -m pip install requests wordfreq cmudict"
+    ) from exc
+
+RDAP_URL = "https://rdap.verisign.com/com/v1/domain/{domain}"
+USER_AGENT = "spoken-domain-finder/1.1 (personal availability research)"
+WORD_RE = re.compile(r"^[a-z]+$")
+
+# Words likely to create mistakes, security concerns, or an odd permanent identity.
+EXCLUDED_WORDS = {
+    "adult", "admin", "bank", "billing", "casino", "crypto", "domain",
+    "email", "finance", "login", "medical", "money", "office", "online",
+    "password", "secure", "support", "verify", "wallet", "webmail",
+}
+
+# Common spoken ambiguities. CMUdict catches additional same-pronunciation words.
+EXCLUDED_HOMOPHONE_PRONE = {
+    "air", "allowed", "ate", "be", "bee", "blue", "buy", "by", "cell",
+    "cent", "dear", "die", "eight", "eye", "fair", "for", "four", "hear",
+    "here", "hour", "know", "mail", "male", "meat", "meet", "new", "no",
+    "one", "our", "pair", "peace", "piece", "plain", "plane", "right",
+    "sea", "see", "son", "sun", "their", "there", "theyre", "to", "too",
+    "two", "wait", "weight", "way", "we", "weak", "week", "weather",
+    "whether", "which", "witch", "wood", "would", "write", "you", "your",
+}
+
+# Positive weighting for words that fit a private family/email domain.
+PREFERRED_PREFIXES = {
+    "all", "den", "home", "house", "inbox", "kin", "oak", "open", "post",
+    "safe", "tree", "true",
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    domain: str
+    prefix: str
+    spoken: str
+    total_length: int
+    score: float
+
+
+def normalized_pronunciation(pron: list[str]) -> tuple[str, ...]:
+    return tuple(re.sub(r"\d", "", phoneme) for phoneme in pron)
+
+
+def parse_lengths(value: str) -> list[int]:
+    try:
+        lengths = sorted({int(part.strip()) for part in value.split(",") if part.strip()})
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("lengths must look like 5,6,7") from exc
+    if not lengths or any(length < 3 or length > 20 for length in lengths):
+        raise argparse.ArgumentTypeError("each total length must be between 3 and 20")
+    return lengths
+
+
+def load_clear_words(max_rank: int, min_zipf: float, max_prefix_length: int) -> dict[str, float]:
+    pronunciations = cmudict.dict()
+    raw_words = top_n_list("en", max_rank)
+
+    words: dict[str, float] = {}
+    for raw in raw_words:
+        word = raw.lower()
+        if not WORD_RE.fullmatch(word):
+            continue
+        if not (2 <= len(word) <= max_prefix_length):
+            continue
+        if word in EXCLUDED_WORDS or word in EXCLUDED_HOMOPHONE_PRONE:
+            continue
+        if word not in pronunciations:
+            continue
+        frequency = zipf_frequency(word, "en")
+        if frequency < min_zipf and word not in PREFERRED_PREFIXES:
+            continue
+        words[word] = frequency
+
+    pronunciation_map: dict[tuple[str, ...], set[str]] = defaultdict(set)
+    for word in words:
+        for pron in pronunciations[word]:
+            pronunciation_map[normalized_pronunciation(pron)].add(word)
+
+    clear: dict[str, float] = {}
+    for word, frequency in words.items():
+        if all(
+            pronunciation_map[normalized_pronunciation(pron)] == {word}
+            for pron in pronunciations[word]
+        ):
+            clear[word] = frequency
+    return clear
+
+
+def generate_candidates(
+    words: dict[str, float], lengths: list[int], suffix: str, included: list[str]
+) -> list[Candidate]:
+    candidates: dict[str, Candidate] = {}
+    suffix_spoken = " ".join(suffix.upper())
+
+    pool = dict(words)
+    for prefix in included:
+        prefix = prefix.lower().strip()
+        if WORD_RE.fullmatch(prefix):
+            pool.setdefault(prefix, zipf_frequency(prefix, "en"))
+
+    for prefix, frequency in pool.items():
+        total_length = len(prefix) + len(suffix)
+        if total_length not in lengths:
+            continue
+        joined = prefix + suffix
+        score = frequency
+        if prefix in PREFERRED_PREFIXES:
+            score += 0.6
+        # Prefer prefixes of at least four letters. Three-letter words are more
+        # likely to be misheard or merged with the spoken M-X suffix.
+        if len(prefix) == 3:
+            score -= 0.4
+        candidate = Candidate(
+            domain=f"{joined}.com",
+            prefix=prefix,
+            spoken=f"{prefix} {suffix_spoken} dot com",
+            total_length=total_length,
+            score=round(score, 3),
+        )
+        candidates[candidate.domain] = candidate
+
+    return sorted(candidates.values(), key=lambda item: (-item.score, item.domain))
+
+
+def load_checked(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    with path.open(newline="", encoding="utf-8") as handle:
+        return {row["domain"] for row in csv.DictReader(handle) if row.get("domain")}
+
+
+def append_result(path: Path, row: dict[str, object]) -> None:
+    new_file = not path.exists()
+    fields = [
+        "domain", "prefix", "spoken", "total_length", "score", "status",
+        "http_status", "checked_at_utc", "note",
+    ]
+    with path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        if new_file:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def rdap_status(
+    session: requests.Session, domain: str, timeout: float, attempts: int = 5
+) -> tuple[str, int | None, str]:
+    url = RDAP_URL.format(domain=domain)
+    for attempt in range(attempts):
+        try:
+            response = session.get(url, timeout=timeout)
+        except requests.RequestException as exc:
+            if attempt == attempts - 1:
+                return "error", None, str(exc)
+            time.sleep(2 ** attempt)
+            continue
+
+        if response.status_code == 200:
+            return "registered", 200, "RDAP record exists"
+        if response.status_code == 404:
+            return "no-rdap-record", 404, "Confirm availability and price at registrar"
+        if response.status_code == 429 or 500 <= response.status_code < 600:
+            if attempt == attempts - 1:
+                return "error", response.status_code, "RDAP rate limit/server error"
+            retry_after = response.headers.get("Retry-After")
+            wait = float(retry_after) if retry_after and retry_after.isdigit() else 2 ** attempt
+            time.sleep(wait)
+            continue
+        return "unknown", response.status_code, response.text[:160].replace("\n", " ")
+    return "error", None, "Unexpected retry exit"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Find short spoken-clear .com domains ending in a fixed suffix."
+    )
+    parser.add_argument("--lengths", type=parse_lengths, default=parse_lengths("5,6,7"))
+    parser.add_argument("--suffix", default="mx", help="Letter suffix before .com (default: mx).")
+    parser.add_argument(
+        "--include", action="append", default=[],
+        help="Force-add a prefix such as busch. Repeat for multiple prefixes.",
+    )
+    parser.add_argument("--checks", type=int, default=500)
+    parser.add_argument("--delay", type=float, default=1.0)
+    parser.add_argument("--max-rank", type=int, default=50000)
+    parser.add_argument("--min-zipf", type=float, default=4.2)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--results", type=Path, default=Path("mx_domain_checks.csv"))
+    parser.add_argument("--candidates", type=Path, default=Path("mx_ranked_candidates.csv"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    suffix = args.suffix.lower().strip()
+    if not WORD_RE.fullmatch(suffix):
+        raise SystemExit("--suffix must contain letters only")
+    max_prefix_length = max(args.lengths) - len(suffix)
+    if max_prefix_length < 2:
+        raise SystemExit("The suffix is too long for the requested total lengths")
+
+    words = load_clear_words(args.max_rank, args.min_zipf, max_prefix_length)
+    candidates = generate_candidates(words, args.lengths, suffix, args.include)
+
+    with args.candidates.open("w", newline="", encoding="utf-8") as handle:
+        fields = ["domain", "prefix", "spoken", "total_length", "score"]
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for candidate in candidates:
+            writer.writerow(candidate.__dict__)
+
+    checked = load_checked(args.results)
+    pending = [candidate for candidate in candidates if candidate.domain not in checked]
+    pending = pending[: args.checks]
+
+    print(f"Generated {len(candidates):,} ranked candidates ending in {suffix}.com.")
+    print(f"Previously checked: {len(checked):,}")
+    print(f"Checking now: {len(pending):,}")
+    print(f"Results: {args.results.resolve()}")
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": USER_AGENT, "Accept": "application/rdap+json"})
+
+    available_count = 0
+    for index, candidate in enumerate(pending, start=1):
+        status, http_status, note = rdap_status(session, candidate.domain, args.timeout)
+        append_result(
+            args.results,
+            {
+                **candidate.__dict__,
+                "status": status,
+                "http_status": http_status or "",
+                "checked_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "note": note,
+            },
+        )
+        if status == "no-rdap-record":
+            available_count += 1
+            print(f"[{index:>4}/{len(pending)}] CANDIDATE  {candidate.domain:<18} {candidate.spoken}")
+        elif index % 25 == 0 or status in {"error", "unknown"}:
+            print(f"[{index:>4}/{len(pending)}] {status:<14} {candidate.domain}")
+        if index < len(pending):
+            time.sleep(max(args.delay, 0.25))
+
+    print(f"\nNo-record candidates found this run: {available_count}")
+    print("Confirm every candidate and any premium price at a registrar.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/wg-ionos-setup.sh
+++ b/tools/wg-ionos-setup.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# wg-ionos-setup.sh — WireGuard "exit node" setup for an IONOS (or any) Ubuntu VPS.
+#
+# Purpose: let a UniFi gateway at home dial this VPS as a WireGuard VPN client,
+# so selected LAN devices (e.g. two Fire TVs) can be policy-routed out through
+# the VPS's German IP.
+#
+#   Fire TV ──▶ UniFi gateway ──(WireGuard tunnel)──▶ this VPS ──▶ internet (DE)
+#
+# Usage (as root on the VPS):
+#   bash wg-ionos-setup.sh              # install + configure + print UniFi config
+#   bash wg-ionos-setup.sh show-client  # reprint the UniFi client config
+#   bash wg-ionos-setup.sh status      # wg status + forwarding/NAT sanity checks
+#
+# Idempotent: keys and config are only generated if missing. Re-running is safe.
+#
+# Remember to also open UDP ${WG_PORT} in the IONOS Cloud Panel firewall —
+# the panel firewall sits in front of the VPS and drops the port otherwise.
+
+set -euo pipefail
+
+WG_IF="${WG_IF:-wg0}"
+WG_PORT="${WG_PORT:-51820}"
+WG_NET="${WG_NET:-10.66.0}"          # /24 base; server=.1, UniFi peer=.2
+WG_DIR="/etc/wireguard"
+SERVER_ADDR="${WG_NET}.1"
+PEER_ADDR="${WG_NET}.2"
+
+info() { printf '\033[1;32m[wg-setup]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[wg-setup]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[wg-setup]\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ "$(id -u)" -eq 0 ] || die "Run as root (sudo bash $0)."
+
+detect_wan() {
+    WAN_IF=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<NF;i++) if ($i=="dev") print $(i+1)}' | head -n1)
+    [ -n "${WAN_IF}" ] || die "Could not detect the default (WAN) interface."
+    PUBLIC_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<NF;i++) if ($i=="src") print $(i+1)}' | head -n1)
+    # VPS interface addresses are usually the public IP; fall back to a lookup.
+    case "${PUBLIC_IP}" in
+        10.*|172.1[6-9].*|172.2[0-9].*|172.3[0-1].*|192.168.*|100.6[4-9].*|100.[7-9]*.*|100.1[0-2]*.*|"")
+            PUBLIC_IP=$(curl -4fsS --max-time 10 https://ifconfig.me 2>/dev/null || true)
+            ;;
+    esac
+    [ -n "${PUBLIC_IP}" ] || die "Could not determine the public IP. Set PUBLIC_IP=x.x.x.x and re-run."
+}
+
+install_packages() {
+    if ! command -v wg >/dev/null 2>&1; then
+        info "Installing WireGuard..."
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y -qq wireguard iptables curl
+    fi
+}
+
+generate_keys() {
+    umask 077
+    mkdir -p "${WG_DIR}"
+    for name in server unifi; do
+        if [ ! -f "${WG_DIR}/${name}.key" ]; then
+            info "Generating ${name} key pair..."
+            wg genkey | tee "${WG_DIR}/${name}.key" | wg pubkey > "${WG_DIR}/${name}.pub"
+        fi
+    done
+}
+
+write_config() {
+    if [ -f "${WG_DIR}/${WG_IF}.conf" ]; then
+        info "${WG_DIR}/${WG_IF}.conf already exists — leaving it untouched."
+        return
+    fi
+    info "Writing ${WG_DIR}/${WG_IF}.conf..."
+    umask 077
+    cat > "${WG_DIR}/${WG_IF}.conf" <<EOF
+[Interface]
+Address = ${SERVER_ADDR}/24
+ListenPort = ${WG_PORT}
+PrivateKey = $(cat "${WG_DIR}/server.key")
+PostUp = iptables -t nat -A POSTROUTING -s ${WG_NET}.0/24 -o ${WAN_IF} -j MASQUERADE; iptables -A FORWARD -i ${WG_IF} -j ACCEPT; iptables -A FORWARD -o ${WG_IF} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+PostDown = iptables -t nat -D POSTROUTING -s ${WG_NET}.0/24 -o ${WAN_IF} -j MASQUERADE; iptables -D FORWARD -i ${WG_IF} -j ACCEPT; iptables -D FORWARD -o ${WG_IF} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# UniFi gateway at home. It source-NATs LAN clients behind ${PEER_ADDR},
+# so a /32 is all the routing this side needs.
+[Peer]
+PublicKey = $(cat "${WG_DIR}/unifi.pub")
+AllowedIPs = ${PEER_ADDR}/32
+EOF
+}
+
+enable_forwarding() {
+    info "Enabling IPv4 forwarding..."
+    cat > /etc/sysctl.d/99-wireguard-forward.conf <<EOF
+net.ipv4.ip_forward = 1
+EOF
+    sysctl -q -p /etc/sysctl.d/99-wireguard-forward.conf
+}
+
+open_firewall() {
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+        info "Allowing UDP ${WG_PORT} in ufw..."
+        ufw allow "${WG_PORT}/udp" >/dev/null
+    fi
+}
+
+start_service() {
+    info "Enabling wg-quick@${WG_IF}..."
+    systemctl enable --now "wg-quick@${WG_IF}" >/dev/null 2>&1 \
+        || systemctl restart "wg-quick@${WG_IF}"
+}
+
+print_client_config() {
+    detect_wan
+    cat <<EOF
+
+============================================================
+ UniFi VPN Client configuration (WireGuard)
+============================================================
+Paste these values in the UniFi Network app under
+Settings -> VPN -> VPN Client -> Create New -> WireGuard:
+
+  Tunnel (interface) IP .... ${PEER_ADDR}/32
+  Private key .............. $(cat "${WG_DIR}/unifi.key")
+  Server (peer) public key . $(cat "${WG_DIR}/server.pub")
+  Endpoint ................. ${PUBLIC_IP}:${WG_PORT}
+  Allowed IPs .............. 0.0.0.0/0
+  Persistent keepalive ..... 25
+
+Equivalent importable wg-quick file:
+
+[Interface]
+PrivateKey = $(cat "${WG_DIR}/unifi.key")
+Address = ${PEER_ADDR}/32
+
+[Peer]
+PublicKey = $(cat "${WG_DIR}/server.pub")
+Endpoint = ${PUBLIC_IP}:${WG_PORT}
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+
+Then route only the Fire TVs through it:
+Settings -> Routing -> Policy-Based Routing -> Create Entry ->
+source: the two Fire TV devices, interface: this VPN client.
+
+If you prefer UniFi to generate its own private key, replace the
+[Peer] PublicKey in ${WG_DIR}/${WG_IF}.conf with UniFi's public
+key and run: systemctl restart wg-quick@${WG_IF}
+============================================================
+EOF
+}
+
+show_status() {
+    wg show "${WG_IF}" || warn "Interface ${WG_IF} is not up."
+    printf 'ip_forward: %s\n' "$(sysctl -n net.ipv4.ip_forward)"
+    iptables -t nat -S POSTROUTING | grep -F "${WG_NET}.0/24" \
+        || warn "No MASQUERADE rule found for ${WG_NET}.0/24."
+}
+
+case "${1:-install}" in
+    install)
+        install_packages
+        detect_wan
+        generate_keys
+        write_config
+        enable_forwarding
+        open_firewall
+        start_service
+        info "Server is up on ${PUBLIC_IP}:${WG_PORT} (interface ${WG_IF})."
+        print_client_config
+        ;;
+    show-client)
+        [ -f "${WG_DIR}/unifi.key" ] || die "No client key yet — run the installer first."
+        print_client_config
+        ;;
+    status)
+        show_status
+        ;;
+    *)
+        die "Unknown command '$1'. Use: install (default), show-client, status."
+        ;;
+esac


### PR DESCRIPTION
Two standalone tools for the IONOS VPS, both under `tools/`.

## `find_mx_coms.py` — spoken-clear .com domain finder
- Generates candidate prefixes from common English words (wordfreq), filtered to words with unambiguous pronunciation (CMUdict) and no homophone collisions
- Ranks candidates by familiarity, with bonuses for family/email-friendly prefixes and penalties for easily-misheard 3-letter words
- Checks each candidate against Verisign's `.com` RDAP service with polite rate limiting, retry/backoff, and resume-across-runs via a results CSV

```bash
python3 -m pip install requests wordfreq cmudict
python3 tools/find_mx_coms.py --lengths 5,6,7 --suffix mx --include busch
```

Verified end-to-end in-session: 1,683 candidates generated, 500 RDAP checks completed with 0 errors.

## `wg-ionos-setup.sh` — WireGuard exit-node installer
One-command WireGuard server setup so a UniFi gateway at home can dial the VPS as a VPN client and policy-route selected LAN devices (e.g. Fire TVs) out through the VPS's German IP.

- Idempotent: keys and config are generated only if missing; safe to re-run
- Auto-detects WAN interface and public IP; NAT masquerade, IPv4 forwarding, optional ufw rule
- Prints ready-to-paste UniFi VPN Client settings plus an importable wg-quick config
- `show-client` reprints the client config; `status` runs sanity checks

```bash
sudo bash tools/wg-ionos-setup.sh
```

Note: UDP 51820 must also be opened in the IONOS Cloud Panel firewall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiB7q73f7ZAAnpYLUuj51a